### PR TITLE
refactor/feat: pluggable schema formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Most backend frameworks ask you to learn their full architecture before you can 
 The entire model fits in your head at once:
 
 - A **Service** exposes a standard set of methods (`find`, `get`, `create`, `update`, `patch`, `remove`) and is automatically mounted as a RESTful HTTP API at a given path.
-- A **Rule** is a single-responsibility function that receives a request context, applies one concern — authentication, validation, rate limiting, logging — and returns either `continue` or `stop`. Rules do not call each other; a flat orchestrator sequences them.
+- A **Rule** is a single-responsibility function that receives a request context, applies one concern - authentication, validation, rate limiting, logging - and returns either `continue` or `stop`. Rules do not call each other; a flat orchestrator sequences them.
 - A **Schema** describes the shape of a service's data. It is used for input validation inside rules and as a structural hint for storage adapters.
 
 There is no magic, no dependency injection container, no decorator metadata, no resolver chain. Every moving piece is visible and explicit. A developer new to the codebase can read a service definition and understand the full execution path in minutes.
@@ -24,7 +24,9 @@ Alumna inherits Crystal's performance characteristics: ahead-of-time compilation
 
 ## Status
 
-Alumna is in active early development. The HTTP layer, rule pipeline, schema validation, in-memory adapter, and JSON/MessagePack serialization are complete and tested. See the [Roadmap](#roadmap) for what is coming next.
+Alumna is in active early development. The HTTP layer, rule pipeline, schema validation (now with pluggable formats resolved at definition time), in-memory adapter, and JSON/MessagePack serialization are complete and tested.
+
+See the [Roadmap](#roadmap) for what is coming next.
 
 ---
 
@@ -78,11 +80,11 @@ UserSchema = Alumna::Schema.new
 
 **Supported field types:** `:str`, `:int`, `:float`, `:bool`, `:nullable` (or `Alumna::FieldType::Str`, etc.)
 
-**Supported formats:** `:email`, `:url`, `:uuid`
+**Supported formats:** `:email`, `:url`, `:uuid` - these are built-in and backed by Crystal's stdlib (`URI.parse`, `UUID.parse`). Formats are resolved once when the schema is defined, so validation is a direct Proc call with no hash lookups at runtime.
 
 **Supported constraints:** `required`, `required_on`, `min_length`, `max_length`, `format`
 
-`required_on` lets a field be required only for specific operations — perfect for PATCH:
+`required_on` lets a field be required only for specific operations - perfect for PATCH:
 
 ```crystal
 PostSchema = Alumna::Schema.new
@@ -90,9 +92,27 @@ PostSchema = Alumna::Schema.new
   .str("body",  required_on: [:create, :update], min_length: 1)
 ```
 
+#### Pluggable formats
+
+Formats are not hard-coded. Alumna ships with `:email`, `:url`, and `:uuid`, but you can register your own once at application boot:
+
+```crystal
+Alumna::Formats.register("hex_color", "must be a valid hex color") do |v|
+  v.matches?(/\A#(?:[0-9a-fA-F]{3}){1,2}\z/)
+end
+
+ProductSchema = Alumna::Schema.new
+  .str("name")
+  .str("color", format: :hex_color)
+```
+
+- Registration happens before schemas are built; the validator Proc is stored in the field descriptor
+- Unknown formats raise `ArgumentError` at schema definition time (fail-fast)
+- Built-in formats follow real-world behavior: UUIDs accept both hyphenated and compact forms, URLs accept surrounding whitespace and require `http` or `https`
+
 **Required by default**
 
-All fields are required unless you pass `required: false` or limit them with `required_on`. This matches Crystal's philosophy of failing fast — you opt out of validation, not into it.
+All fields are required unless you pass `required: false` or limit them with `required_on`. This matches Crystal's philosophy of failing fast - you opt out of validation, not into it.
 
 | Declaration | Result |
 |---|---|
@@ -144,7 +164,7 @@ errors = PostSchema.validate(ctx.data, ctx.method)
 
 ### Rules
 
-A rule is a `Proc` that receives a `RuleContext` and returns a `RuleResult`. Rules are values, not classes — they are defined once and registered on one or more services.
+A rule is a `Proc` that receives a `RuleContext` and returns a `RuleResult`. Rules are values, not classes - they are defined once and registered on one or more services.
 
 ```crystal
 # A rule that checks for a valid bearer token
@@ -359,19 +379,19 @@ end
 
 ## Roadmap
 
-### v0.3 — First real database adapter: SQLite
+### v0.3 - First real database adapter: SQLite
 - SQLite adapter for lightweight single-file deployments
 - Using [crystal-sqlite3](https://github.com/crystal-lang/crystal-sqlite3)
 - Adapter reads the service schema to introspect column names and types
 - Supports schema-driven migration hints (not full migration management, which is left to dedicated tools)
 
-### v0.4 — MySQl and PostgreSQL database adapters
+### v0.4 - MySQl and PostgreSQL database adapters
 - MySQl adapter using [crystal-db](https://github.com/crystal-lang/crystal-db) and [crystal-mysql](https://github.com/crystal-lang/crystal-mysql)
 - PostgreSQL adapter using [crystal-db](https://github.com/crystal-lang/crystal-db) and [crystal-pg](https://github.com/will/crystal-pg)
 - Adapter reads the service schema to introspect column names and types
 - Supports schema-driven migration hints (not full migration management, which is left to dedicated tools)
 
-### v0.5 — Real-time events via WebSocket
+### v0.5 - Real-time events via WebSocket
 - Emit service events automatically after successful mutations (`created`, `updated`, `patched`, `removed`)
 - Allow clients to subscribe to specific service paths over a WebSocket connection
 - Rules gain access to an `event` field on the context to suppress or transform events before they are emitted
@@ -380,15 +400,15 @@ end
 ### v0.6 - Redis adapter for cache
 - Redis adapter using [jgaskins/redis](https://github.com/jgaskins/redis)
 
-### v0.6 — NATS integration for horizontal scaling
+### v0.6 - NATS integration for horizontal scaling
 - Stateless service instances publish events to NATS subjects mirroring the service path and method (e.g. `alumna.users.created`)
 - WebSocket gateway subscribes to NATS and fans events out to connected clients
 - Enables multiple Alumna instances behind a load balancer to correctly propagate real-time events across all nodes
 - NATS chosen over AMQP for operational simplicity and natural subject-based routing
 
-### v0.7 — Automated test helpers
-- `Alumna::Testing::ServiceClient` — call service methods directly without an HTTP layer, for fast unit tests
-- `Alumna::Testing::RuleRunner` — execute a single rule against a fabricated context and assert on the result
+### v0.7 - Automated test helpers
+- `Alumna::Testing::ServiceClient` - call service methods directly without an HTTP layer, for fast unit tests
+- `Alumna::Testing::RuleRunner` - execute a single rule against a fabricated context and assert on the result
 - Spec helpers for asserting on context state after dispatch
 
 
@@ -407,7 +427,16 @@ end
 
 **Why no resolvers?** FeathersJS resolvers automatically transform the result payload based on the requesting context. Alumna omits them in favour of explicit after-rules that transform `ctx.result` directly. This is slightly more code in trivial cases but significantly easier to debug and reason about when something goes wrong.
 
-**Why `ServiceResult` instead of `JSON::Any` for the result type?** A typed union of `Hash | Array | Nil` lets the responder dispatch on the actual type rather than inspecting a wrapped value at runtime. It also removes the dependency on `JSON::Any` internals from the context, making the context format-agnostic.
+**Why `ServiceResult` uses `AnyData` instead of `JSON::Any`?** 
+
+Alumna defines its own recursive union:
+
+```crystal
+alias AnyData = Nil | Bool | Int64 | Float64 | String | Array(AnyData) | Hash(String, AnyData)
+alias ServiceResult = Hash(String, AnyData) | Array(Hash(String, AnyData)) | Nil
+```
+
+This lets every layer - context, services, rules, and serializers - work with native Crystal values instead of a wrapper type. The responder can dispatch on the actual type, MessagePack serializes without unwrapping, and validation errors flow through as plain hashes. It removes the `JSON::Any` dependency from the core, makes the context format-agnostic, and gives the compiler full visibility into data shapes for better errors and zero-cost abstractions.
 
 **Why Crystal?** Expressive syntax that lowers the barrier for developers coming from Ruby or TypeScript. AOT compilation and a single binary output that eliminates runtime dependency management at deploy time. Performance that competes with Go, C and Rust _(see [LangArena](https://kostya.github.io/LangArena/))_ without sacrificing readability. The type system catches a large class of bugs at compile time that dynamic languages surface only in production.
 

--- a/spec/schema/base_spec.cr
+++ b/spec/schema/base_spec.cr
@@ -33,24 +33,29 @@ describe Alumna::Schema do
   describe "format" do
     it "accepts :email, :url, :uuid" do
       s = Alumna::Schema.new.str("e", format: :email)
-      s.fields.first.format.should eq(Alumna::FieldFormat::Email)
+      fd = s.fields.first
+      fd.format_name.should eq("email")
+      fd.format_validator.should_not be_nil
+      fd.format_message.should eq("must be a valid email address")
     end
 
-    it "accepts enum directly and capitalized symbols" do
-      s1 = Alumna::Schema.new.field("x", :str, format: Alumna::FieldFormat::Url)
-      s1.fields.first.format.should eq(Alumna::FieldFormat::Url)
+    it "normalizes strings and capitalized symbols" do
+      s1 = Alumna::Schema.new.field("x", :str, format: :url)
+      s1.fields.first.format_name.should eq("url")
 
-      s2 = Alumna::Schema.new.str("y", format: :Uuid)
-      s2.fields.first.format.should eq(Alumna::FieldFormat::Uuid)
+      s2 = Alumna::Schema.new.str("y", format: "Uuid")
+      s2.fields.first.format_name.should eq("uuid")
     end
 
     it "allows nil" do
-      Alumna::Schema.new.str("n").fields.first.format.should be_nil
+      fd = Alumna::Schema.new.str("n").fields.first
+      fd.format_name.should be_nil
+      fd.format_validator.should be_nil
+      fd.format_message.should be_nil
     end
 
-    # FIXED: Crystal's message is "Unknown enum...", not "Invalid FieldFormat"
     it "raises for unknown format" do
-      expect_raises(ArgumentError, /Unknown enum Alumna::FieldFormat/) do
+      expect_raises(ArgumentError, /Unknown format/) do
         Alumna::Schema.new.str("x", format: :not_a_format)
       end
     end

--- a/spec/schema/validator_spec.cr
+++ b/spec/schema/validator_spec.cr
@@ -179,24 +179,25 @@ describe Alumna::Schema do
   # ── Format constraints ────────────────────────────────────────────────────────
 
   describe "Email format" do
-    schema = Alumna::Schema.new.field("email", Alumna::FieldType::Str, format: Alumna::FieldFormat::Email)
+    schema = Alumna::Schema.new.field("email", Alumna::FieldType::Str, format: :email)
 
     it "accepts a valid email" { errors_for(schema, {"email" => any("alice@example.com")}).should be_empty }
     it "rejects missing @" { error_on(schema, {"email" => any("notanemail")}, "email").should eq("must be a valid email address") }
   end
 
   describe "Url format" do
-    schema = Alumna::Schema.new.field("url", Alumna::FieldType::Str, format: Alumna::FieldFormat::Url)
+    schema = Alumna::Schema.new.field("url", Alumna::FieldType::Str, format: :url)
 
     it "accepts https URL" { errors_for(schema, {"url" => any("https://example.com/path?q=1")}).should be_empty }
     it "rejects plain domain" { error_on(schema, {"url" => any("example.com")}, "url").should eq("must be a valid URL (http or https)") }
   end
 
   describe "Uuid format" do
-    schema = Alumna::Schema.new.field("id", Alumna::FieldType::Str, format: Alumna::FieldFormat::Uuid)
+    schema = Alumna::Schema.new.field("id", Alumna::FieldType::Str, format: :uuid)
 
     it "accepts a lowercase UUID" { errors_for(schema, {"id" => any("550e8400-e29b-41d4-a716-446655440000")}).should be_empty }
-    it "rejects missing hyphens" { error_on(schema, {"id" => any("550e8400e29b41d4a716446655440000")}, "id").should eq("must be a valid UUID") }
+    it "accepts UUID without hyphens" { errors_for(schema, {"id" => any("550e8400e29b41d4a716446655440000")}).should be_empty }
+    it "rejects invalid UUID" { error_on(schema, {"id" => any("550e8400e29b41d4a71644665544")}, "id").should eq("must be a valid UUID") }
   end
 
   # ── Constraint skipping on type error ────────────────────────────────────────
@@ -204,7 +205,7 @@ describe Alumna::Schema do
   describe "skipping length/format checks when type is wrong" do
     schema = Alumna::Schema.new.field("email", Alumna::FieldType::Str,
       min_length: 5,
-      format: Alumna::FieldFormat::Email
+      format: :email
     )
 
     it "reports only the type error" do
@@ -234,7 +235,7 @@ describe Alumna::Schema do
     it "returns multiple errors for one field" do
       schema = Alumna::Schema.new.field("email", Alumna::FieldType::Str,
         min_length: 10,
-        format: Alumna::FieldFormat::Email
+        format: :email
       )
       # "a@b" is too short AND fails the email regex (no TLD)
       errs = errors_for(schema, {"email" => any("a@b")})
@@ -249,13 +250,18 @@ describe Alumna::Schema do
     end
 
     it "accepts uppercase UUID" do
-      schema = Alumna::Schema.new.field("id", Alumna::FieldType::Str, format: Alumna::FieldFormat::Uuid)
+      schema = Alumna::Schema.new.field("id", Alumna::FieldType::Str, format: :uuid)
       errors_for(schema, {"id" => any("550E8400-E29B-41D4-A716-446655440000")}).should be_empty
     end
 
-    it "rejects URL with trailing space" do
-      schema = Alumna::Schema.new.field("u", Alumna::FieldType::Str, format: Alumna::FieldFormat::Url)
-      error_on(schema, {"u" => any("https://example.com ")}, "u").should eq("must be a valid URL (http or https)")
+    it "accepts URL with surrounding whitespace" do
+      schema = Alumna::Schema.new.field("u", Alumna::FieldType::Str, format: :url)
+      errors_for(schema, {"u" => any("  https://example.com  ")}).should be_empty
+    end
+
+    it "rejects URL with internal space" do
+      schema = Alumna::Schema.new.field("u", Alumna::FieldType::Str, format: :url)
+      error_on(schema, {"u" => any("https://exa mple.com")}, "u").should eq("must be a valid URL (http or https)")
     end
 
     it "required_on implies presence even when required: false" do

--- a/src/alumna.cr
+++ b/src/alumna.cr
@@ -21,6 +21,10 @@ require "./service/error"
 
 # Schema — depends only on primitives
 require "./schema/base"
+require "./schema/formats/registry"
+require "./schema/formats/email"
+require "./schema/formats/url"
+require "./schema/formats/uuid"
 require "./schema/validator"
 
 # Rule — depends on phase; context not yet defined, Rule is just a Proc alias

--- a/src/schema/base.cr
+++ b/src/schema/base.cr
@@ -6,7 +6,9 @@ module Alumna
     getter required_on : Array(ServiceMethod)?
     getter min_length : Int32?
     getter max_length : Int32?
-    getter format : FieldFormat?
+    getter format_name : String?
+    getter format_validator : Proc(String, Bool)?
+    getter format_message : String?
 
     def initialize(
       @name : String,
@@ -14,14 +16,12 @@ module Alumna
       @required : Bool = true,
       @min_length : Int32? = nil,
       @max_length : Int32? = nil,
-      @format : FieldFormat? = nil,
+      @format_name : String? = nil,
+      @format_validator : Proc(String, Bool)? = nil,
+      @format_message : String? = nil,
       @required_on : Array(ServiceMethod)? = nil,
     )
     end
-  end
-
-  enum FieldFormat
-    Email; Url; Uuid
   end
 
   enum FieldType
@@ -42,14 +42,32 @@ module Alumna
       required : Bool = true,
       min_length : Int32? = nil,
       max_length : Int32? = nil,
-      format : FieldFormat | Symbol | Nil = nil,
+      format : Symbol | String | Nil = nil,
       required_on : Array(ServiceMethod | Symbol) | Nil = nil,
     ) : self
       # normalize :str → FieldType::Str
       field_type = type.is_a?(Symbol) ? FieldType.parse(type.to_s.capitalize) : type
 
-      # normalize :email → FieldFormat::Email   ← NEW
-      norm_format = format.is_a?(Symbol) ? FieldFormat.parse(format.to_s.capitalize) : format
+      # normalize format to downcased string, resolve validator once
+      format_name = nil
+      format_validator = nil
+      format_message = nil
+
+      if format
+        format_name = case format
+                      when Symbol then format.to_s.downcase
+                      when String then format.downcase
+                      end
+
+        if format_name
+          if entry = Formats.fetch(format_name)
+            format_validator = entry.validator
+            format_message = entry.message
+          else
+            raise ArgumentError.new("Unknown format: #{format_name}")
+          end
+        end
+      end
 
       # normalize :create → ServiceMethod::Create
       norm_required_on = required_on.try &.map do |m|
@@ -62,7 +80,9 @@ module Alumna
         required: required,
         min_length: min_length,
         max_length: max_length,
-        format: norm_format,
+        format_name: format_name,
+        format_validator: format_validator,
+        format_message: format_message,
         required_on: norm_required_on,
       )
       self

--- a/src/schema/formats/email.cr
+++ b/src/schema/formats/email.cr
@@ -1,0 +1,3 @@
+Alumna::Formats.register("email", "must be a valid email address") do |v|
+  v.size <= 254 && v.count('@') == 1 && v.matches?(/\A[^@\s]+@[^@\s]+\.[^@\s]+\z/)
+end

--- a/src/schema/formats/registry.cr
+++ b/src/schema/formats/registry.cr
@@ -1,0 +1,17 @@
+module Alumna
+  module Formats
+    alias Validator = Proc(String, Bool)
+
+    record Entry, validator : Validator, message : String
+
+    @@registry = {} of String => Entry
+
+    def self.register(name : String | Symbol, message : String, &block : String -> Bool)
+      @@registry[name.to_s] = Entry.new(block, message)
+    end
+
+    def self.fetch(name : String) : Entry?
+      @@registry[name]?
+    end
+  end
+end

--- a/src/schema/formats/url.cr
+++ b/src/schema/formats/url.cr
@@ -1,0 +1,8 @@
+require "uri"
+
+Alumna::Formats.register("url", "must be a valid URL (http or https)") do |v|
+  s = v.strip
+  next false if s.empty? || s.includes?(' ')
+  uri = URI.parse(s) rescue nil
+  !!(uri && (uri.scheme == "http" || uri.scheme == "https") && !uri.host.to_s.empty?)
+end

--- a/src/schema/formats/uuid.cr
+++ b/src/schema/formats/uuid.cr
@@ -1,0 +1,5 @@
+require "uuid"
+
+Alumna::Formats.register("uuid", "must be a valid UUID") do |v|
+  !UUID.parse?(v).nil?
+end

--- a/src/schema/validator.cr
+++ b/src/schema/validator.cr
@@ -8,10 +8,6 @@ module Alumna
   end
 
   class Schema
-    EMAIL_REGEX = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
-    URL_REGEX   = /\Ahttps?:\/\/[^\s]+\z/
-    UUID_REGEX  = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
-
     def validate(data : Hash(String, AnyData), method : ServiceMethod? = nil) : Array(FieldError)
       errors = [] of FieldError
 
@@ -55,9 +51,9 @@ module Alumna
               errors << FieldError.new(field.name, "must be at most #{max} character#{max == 1 ? "" : "s"}")
             end
           end
-          if fmt = field.format
-            unless valid_format?(str, fmt)
-              errors << FieldError.new(field.name, format_message(fmt))
+          if validator = field.format_validator
+            unless validator.call(str)
+              errors << FieldError.new(field.name, field.format_message || "has an invalid format")
             end
           end
         end
@@ -77,24 +73,6 @@ module Alumna
         value.is_a?(Bool) ? nil : "must be true or false"
       else
         nil
-      end
-    end
-
-    private def valid_format?(value : String, format : FieldFormat) : Bool
-      case format
-      when .email? then !!(value =~ EMAIL_REGEX)
-      when .url?   then !!(value =~ URL_REGEX)
-      when .uuid?  then !!(value =~ UUID_REGEX)
-      else              true
-      end
-    end
-
-    private def format_message(format : FieldFormat) : String
-      case format
-      when .email? then "must be a valid email address"
-      when .url?   then "must be a valid URL (http or https)"
-      when .uuid?  then "must be a valid UUID"
-      else              "has an invalid format"
       end
     end
   end


### PR DESCRIPTION
#### Pluggable formats

Formats are not hard-coded anymore, becoming pluggable.

Alumna now ships common ones of `:email`, `:url`, and `:uuid` for convenience but you **can** register your own once at application boot:

```crystal
Alumna::Formats.register("hex_color", "must be a valid hex color") do |v|
  v.matches?(/\A#(?:[0-9a-fA-F]{3}){1,2}\z/)
end

ProductSchema = Alumna::Schema.new
  .str("name")
  .str("color", format: :hex_color)
```

- Registration happens before schemas are built; the validator Proc is stored in the field descriptor
- No more hash lookups on runtime
- Unknown formats raise `ArgumentError` at schema definition time (fail-fast)
- Built-in formats now follow real-world behavior: UUIDs accept both hyphenated and compact forms, URLs accept surrounding whitespace and require `http` or `https`