### PR TITLE
feat: global app rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Most backend frameworks ask you to learn their full architecture before you can 
 The entire model fits in your head at once:
 
 - A **Service** exposes a standard set of methods (`find`, `get`, `create`, `update`, `patch`, `remove`) and is automatically mounted as a RESTful HTTP API at a given path.
-- A **Rule** is a single-responsibility function that receives a request context, applies one concern - authentication, validation, rate limiting, logging - and returns either `continue` or `stop`. Rules do not call each other; a flat orchestrator sequences them.
+- A **Rule** is a single-responsibility function that receives a request context, applies one concern - authentication, validation, rate limiting, logging - and returns either `continue` or `stop`. Rules do not call each other; a flat orchestrator sequences them. Rules can be registered globally on the app or per-service.
 - A **Schema** describes the shape of a service's data. It is used for input validation inside rules and as a structural hint for storage adapters.
 
 There is no magic, no dependency injection container, no decorator metadata, no resolver chain. Every moving piece is visible and explicit. A developer new to the codebase can read a service definition and understand the full execution path in minutes.
@@ -164,7 +164,7 @@ errors = PostSchema.validate(ctx.data, ctx.method)
 
 ### Rules
 
-A rule is a `Proc` that receives a `RuleContext` and returns a `RuleResult`. Rules are values, not classes - they are defined once and registered on one or more services.
+A rule is a `Proc` that receives a `RuleContext` and returns a `RuleResult`. Rules are values, not classes - they are defined once and registered globally on the application or on individual services.
 
 ```crystal
 # A rule that checks for a valid bearer token
@@ -193,7 +193,7 @@ end
 | `ctx.headers` | `Hash(String, String)` | Request headers, lowercased |
 | `ctx.id` | `String?` | Record ID from the URL, if present |
 | `ctx.data` | `Hash(String, AnyData)` | Parsed request body |
-| `ctx.result` | `ServiceResult` | Response payload; set this in a before-rule to skip the service call entirely |
+| `ctx.result` | `ServiceResult` | Response payload; set this in a before-rule to skip the service method (after-rules still run) |
 | `ctx.error` | `ServiceError?` | Present when the pipeline is in the error phase |
 | `ctx.http.status` | `Int32?` | Override the HTTP response status code |
 | `ctx.http.headers` | `Hash(String, String)` | Add custom HTTP response headers |
@@ -248,12 +248,31 @@ end
 | `patch` | `PATCH` | `/users/:id` |
 | `remove` | `DELETE` | `/users/:id` |
 
+
+**Execution order:**
+
+When a request arrives, rules run in this exact sequence:
+
+1. `app.before` rules
+2. `service.before` rules
+3. service method (`find`, `get`, etc.) — skipped if a before-rule set `ctx.result`
+4. `service.after` rules
+5. `app.after` rules
+
+After-rules always run when there is no error, even if a before-rule short-circuited the service method. This makes logging, metrics, and response headers reliable.
+
 ---
 
 ### Application
 
 ```crystal
 app = Alumna::App.new
+
+# Global rules run for every service
+app.before CORS
+app.before RateLimit
+app.after Logger
+
 app.use("/users", UserService.new)
 app.listen(3000)
 ```

--- a/spec/rule/ruleable_spec.cr
+++ b/spec/rule/ruleable_spec.cr
@@ -1,0 +1,101 @@
+require "../spec_helper"
+
+class DummyRuleable
+  include Alumna::Ruleable
+end
+
+private def dummy_context : Alumna::RuleContext
+  app = Alumna::App.new
+  service = Alumna::MemoryAdapter.new("/dummy")
+  Alumna::RuleContext.new(
+    app: app,
+    service: service,
+    path: "/dummy",
+    method: Alumna::ServiceMethod::Find,
+    phase: Alumna::RulePhase::Before
+  )
+end
+
+describe Alumna::Ruleable do
+  rule = ->(ctx : Alumna::RuleContext) { Alumna::RuleResult.continue }
+
+  it "registers global before rules" do
+    r = DummyRuleable.new.before(rule)
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
+  end
+
+  it "registers specific after rules with symbols" do
+    r = DummyRuleable.new.after(rule, only: [:create, :update])
+    creates = r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::After)
+    finds = r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::After)
+    creates.size.should eq(1)
+    finds.size.should eq(0)
+  end
+
+  it "normalizes symbols to enums" do
+    r = DummyRuleable.new.before(rule, only: :patch)
+    r.collect_rules(Alumna::ServiceMethod::Patch, Alumna::RulePhase::Before).size.should eq(1)
+  end
+
+  it "accepts single enum overload for before" do
+    r = DummyRuleable.new
+    r.before(rule, only: Alumna::ServiceMethod::Find)
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
+  end
+
+  it "accepts single symbol and normalizes via capitalize" do
+    r = DummyRuleable.new
+    r.before(rule, only: :create)
+    r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Before).size.should eq(1)
+  end
+
+  it "accepts uppercase symbol for after" do
+    r = DummyRuleable.new
+    r.after(rule, only: :FIND)
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::After).size.should eq(1)
+  end
+
+  it "accepts array of symbols" do
+    r = DummyRuleable.new
+    r.before(rule, only: [:find, :create])
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Before).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Get, Alumna::RulePhase::Before).size.should eq(0)
+  end
+
+  it "runs global before specific" do
+    r = DummyRuleable.new
+    order = [] of String
+    global = Alumna::Rule.new { order << "global"; Alumna::RuleResult.continue }
+    specific = Alumna::Rule.new { order << "specific"; Alumna::RuleResult.continue }
+
+    r.before(global)
+    r.before(specific, only: :get)
+
+    rules = r.collect_rules(Alumna::ServiceMethod::Get, Alumna::RulePhase::Before)
+    Alumna::Orchestrator.run(rules, dummy_context)
+
+    order.should eq(["global", "specific"])
+  end
+
+  it "preserves insertion order" do
+    r = DummyRuleable.new
+    r.before(rule).before(rule).after(rule)
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(2)
+  end
+
+  it "returns self for chaining" do
+    r = DummyRuleable.new
+    (r.before(rule).after(rule)).should be(r)
+  end
+
+  it "works identically in App and Service" do
+    app = Alumna::App.new
+    svc = Alumna::MemoryAdapter.new("/test")
+    app.before(rule)
+    svc.before(rule, only: :find)
+
+    app.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
+    svc.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
+  end
+end

--- a/spec/service/base_spec.cr
+++ b/spec/service/base_spec.cr
@@ -70,49 +70,6 @@ private def rule(log : Array(String), label : String) : Alumna::Rule
 end
 
 describe "Service::Base" do
-  describe "symbol-friendly registration API" do
-    it "calls the single-value overload for before (line 15)" do
-      log = [] of String
-      svc = TrackedService.new
-      # uses def before(rule, only : ServiceMethod | Symbol)
-      svc.before(rule(log, "single-enum"), only: Alumna::ServiceMethod::Find)
-
-      svc.dispatch(make_ctx(svc, Alumna::ServiceMethod::Find))
-      log.should eq(["single-enum"])
-    end
-
-    it "accepts a single Symbol and normalizes via capitalize" do
-      log = [] of String
-      svc = TrackedService.new
-      svc.before(rule(log, "sym"), only: :create) # :create -> "Create"
-
-      svc.dispatch(make_ctx(svc, Alumna::ServiceMethod::Create))
-      log.should eq(["sym"])
-      svc.called.should eq(["create"])
-    end
-
-    it "accepts a single Symbol for after (line 19)" do
-      log = [] of String
-      svc = TrackedService.new
-      svc.after(rule(log, "after-sym"), only: :FIND) # tests capitalize handling
-
-      svc.dispatch(make_ctx(svc, Alumna::ServiceMethod::Find))
-      log.should eq(["after-sym"])
-    end
-
-    it "accepts an array of Symbols" do
-      log = [] of String
-      svc = TrackedService.new
-      svc.before(rule(log, "multi"), only: [:find, :create])
-
-      svc.dispatch(make_ctx(svc, Alumna::ServiceMethod::Find))
-      svc.dispatch(make_ctx(svc, Alumna::ServiceMethod::Create))
-      svc.dispatch(make_ctx(svc, Alumna::ServiceMethod::Get)) # should not fire
-
-      log.should eq(["multi", "multi"])
-    end
-  end
-
   describe "error boundary in call_method" do
     it "wraps a raised Exception with message into 500 (line 96)" do
       svc = ExplodingService.new

--- a/spec/service/dispatch_spec.cr
+++ b/spec/service/dispatch_spec.cr
@@ -167,39 +167,86 @@ describe "Service#dispatch" do
     end
   end
 
-  # ── Global vs method-specific ordering ───────────────────────────────────────
+  # ── Global vs method-specific rules ───────────────────────────────────────
 
-  describe "global vs method-specific rule ordering" do
-    it "runs global before rules ahead of method-specific before rules" do
+  describe "global vs method-specific rules" do
+    it "runs app rules around service rules" do
       log = [] of String
-      service = TrackedService.new
 
-      service.before(
-        continuing_rule(log, "specific"),
-        only: [Alumna::ServiceMethod::Find]
+      app = Alumna::App.new
+      svc = Alumna::MemoryAdapter.new("/ordered")
+
+      app.before(Alumna::Rule.new { log << "app-before"; Alumna::RuleResult.continue })
+      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
+
+      svc.before(Alumna::Rule.new { log << "svc-before"; Alumna::RuleResult.continue })
+      svc.after(Alumna::Rule.new { log << "svc-after"; Alumna::RuleResult.continue })
+
+      app.use("/ordered", svc)
+
+      ctx = Alumna::RuleContext.new(
+        app: app,
+        service: svc,
+        path: "/ordered",
+        method: Alumna::ServiceMethod::Find,
+        phase: Alumna::RulePhase::Before
       )
-      service.before(continuing_rule(log, "global"))
 
-      ctx = make_ctx(service, Alumna::ServiceMethod::Find)
-      service.dispatch(ctx)
+      app.dispatch(svc, ctx) # use the new App#dispatch, not svc.dispatch
 
-      log.should eq(["global", "specific"])
+      log.should eq(["app-before", "svc-before", "svc-after", "app-after"])
     end
 
-    it "runs global after rules ahead of method-specific after rules" do
+    it "skips service and app.after when app.before stops" do
       log = [] of String
-      service = TrackedService.new
+      app = Alumna::App.new
+      svc = TrackedService.new
 
-      service.after(
-        continuing_rule(log, "specific"),
-        only: [Alumna::ServiceMethod::Find]
-      )
-      service.after(continuing_rule(log, "global"))
+      app.before(Alumna::Rule.new { log << "app-before"; Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized) })
+      svc.before(Alumna::Rule.new { log << "svc-before"; Alumna::RuleResult.continue })
+      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
 
-      ctx = make_ctx(service, Alumna::ServiceMethod::Find)
-      service.dispatch(ctx)
+      ctx = make_ctx(svc, Alumna::ServiceMethod::Find)
+      ctx = Alumna::RuleContext.new(app: app, service: svc, path: "/x", method: Alumna::ServiceMethod::Find, phase: Alumna::RulePhase::Before)
 
-      log.should eq(["global", "specific"])
+      app.dispatch(svc, ctx)
+      log.should eq(["app-before"])
+      svc.called.should be_empty
+    end
+
+    it "skips service but still runs app.after when app.before sets result" do
+      # this documents current behavior: result_set stops service, not app.after
+      log = [] of String
+      app = Alumna::App.new
+      svc = TrackedService.new
+
+      app.before(Alumna::Rule.new { |c|
+        c.result = {"cached" => true} of String => Alumna::AnyData
+        log << "app-before"
+        Alumna::RuleResult.continue
+      })
+      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
+
+      ctx = Alumna::RuleContext.new(app: app, service: svc, path: "/x", method: Alumna::ServiceMethod::Find, phase: Alumna::RulePhase::Before)
+      app.dispatch(svc, ctx)
+
+      log.should eq(["app-before", "app-after"])
+      svc.called.should be_empty
+    end
+
+    it "skips app.after when service errors" do
+      log = [] of String
+      app = Alumna::App.new
+      svc = TrackedService.new
+
+      svc.before(stopping_rule("boom"))
+      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
+
+      ctx = make_ctx(svc, Alumna::ServiceMethod::Find)
+      ctx = Alumna::RuleContext.new(app: app, service: svc, path: "/x", method: Alumna::ServiceMethod::Find, phase: Alumna::RulePhase::Before)
+
+      app.dispatch(svc, ctx)
+      log.should be_empty
     end
   end
 
@@ -258,7 +305,7 @@ describe "Service#dispatch" do
       service.called.should be_empty
     end
 
-    it "does not run after rules" do
+    it "run after rules even with result already set" do
       log = [] of String
       service = TrackedService.new
 
@@ -268,7 +315,7 @@ describe "Service#dispatch" do
       ctx = make_ctx(service, Alumna::ServiceMethod::Find)
       service.dispatch(ctx)
 
-      log.should be_empty
+      log.should eq(["after"])
     end
 
     it "preserves the result set by the before rule" do

--- a/src/alumna.cr
+++ b/src/alumna.cr
@@ -1,8 +1,6 @@
 module Alumna
   VERSION = "0.2.5"
 
-  # Returns a ready-to-use validation rule for a schema.
-  # Usage: before Alumna.validate(UserSchema), only: [:create, :update, :patch]
   def self.validate(schema : Schema) : Rule
     Rule.new do |ctx|
       errors = schema.validate(ctx.data, ctx.method)
@@ -13,11 +11,20 @@ module Alumna
   end
 end
 
-# Core enums and primitives first — no dependencies
+# Core enums and primitives — no dependencies
 require "./core/types"
 require "./service/method"
 require "./rule/phase"
 require "./service/error"
+
+# --- Solving a circular dependency ---
+# RuleContext needs App and Service as types, but App/Service need Rule.
+# Forward-declare them so context can compile.
+module Alumna
+  class App; end
+
+  abstract class Service; end
+end
 
 # Schema — depends only on primitives
 require "./schema/base"
@@ -27,18 +34,16 @@ require "./schema/formats/url"
 require "./schema/formats/uuid"
 require "./schema/validator"
 
-# Rule — depends on phase; context not yet defined, Rule is just a Proc alias
-require "./rule/base"
-
-# Context — depends on App, Service, ServiceMethod, RulePhase, ServiceError, HttpOverrides
-# App and Service are forward-referenced here, so they must be required immediately after
+# Context — now safe because App and Service exist as forward declarations
 require "./service/context"
-require "./app"
 
-# Orchestrator — depends on Rule, RuleContext
+# Rule — now safe because RuleContext exists
+require "./rule/base"
 require "./rule/orchestrator"
+require "./rule/ruleable"
 
-# Service base — depends on everything above
+# Full implementations — these reopen the forward-declared classes
+require "./app"
 require "./service/base"
 
 # Adapter — depends on Service base

--- a/src/app.cr
+++ b/src/app.cr
@@ -2,6 +2,9 @@ require "http/server"
 
 module Alumna
   class App
+    # before and after rules can be applied at the app (global) level
+    include Ruleable
+
     getter serializer : Http::Serializer
     getter services : Hash(String, Service)
 
@@ -15,6 +18,25 @@ module Alumna
     def use(path : String, service : Service) : self
       @services[path] = service
       self
+    end
+
+    # central dispatch that wraps service dispatch
+    def dispatch(service : Service, ctx : RuleContext) : RuleContext
+      # 1. app before
+      ctx.phase = RulePhase::Before
+      Orchestrator.run(collect_rules(ctx.method, RulePhase::Before), ctx)
+      return ctx if ctx.error
+
+      # 2. service (includes its own before/after)
+      unless ctx.result_set?
+        service.dispatch(ctx)
+        return ctx if ctx.error
+      end
+
+      # 3. app after
+      ctx.phase = RulePhase::After
+      Orchestrator.run(collect_rules(ctx.method, RulePhase::After), ctx)
+      ctx
     end
 
     def listen(port : Int32 = 3000)

--- a/src/http/router.cr
+++ b/src/http/router.cr
@@ -71,7 +71,7 @@ module Alumna
           data: data
         )
 
-        service.dispatch(ctx)
+        ctx.app.dispatch(service, ctx)
         Responder.write(response, ctx, output_serializer)
       end
 

--- a/src/rule/ruleable.cr
+++ b/src/rule/ruleable.cr
@@ -1,0 +1,48 @@
+module Alumna
+  module Ruleable
+    alias RuleMap = Hash(ServiceMethod?, Hash(RulePhase, Array(Rule)))
+
+    @rules : RuleMap = RuleMap.new
+
+    # --- public API ---
+
+    def before(rule : Rule, only : ServiceMethod | Symbol) : self
+      before(rule, only: [only])
+    end
+
+    def after(rule : Rule, only : ServiceMethod | Symbol) : self
+      after(rule, only: [only])
+    end
+
+    def before(rule : Rule, only : Array(ServiceMethod | Symbol) = [] of ServiceMethod) : self
+      register_rule(RulePhase::Before, normalize_methods(only), rule)
+      self
+    end
+
+    def after(rule : Rule, only : Array(ServiceMethod | Symbol) = [] of ServiceMethod) : self
+      register_rule(RulePhase::After, normalize_methods(only), rule)
+      self
+    end
+
+    # --- used by dispatch ---
+
+    def collect_rules(method : ServiceMethod, phase : RulePhase) : Array(Rule)
+      global = @rules[nil]?.try(&.[phase]?) || [] of Rule
+      specific = @rules[method]?.try(&.[phase]?) || [] of Rule
+      global + specific
+    end
+
+    private def register_rule(phase : RulePhase, methods : Array(ServiceMethod), rule : Rule)
+      targets = methods.empty? ? [nil] : methods.map(&.as(ServiceMethod?))
+      targets.each do |target|
+        @rules[target] ||= {} of RulePhase => Array(Rule)
+        @rules[target][phase] ||= [] of Rule
+        @rules[target][phase] << rule
+      end
+    end
+
+    private def normalize_methods(only) : Array(ServiceMethod)
+      only.map { |m| m.is_a?(Symbol) ? ServiceMethod.parse(m.to_s.capitalize) : m }
+    end
+  end
+end

--- a/src/service/base.cr
+++ b/src/service/base.cr
@@ -1,39 +1,12 @@
 module Alumna
   abstract class Service
-    alias RuleMap = Hash(ServiceMethod?, Hash(RulePhase, Array(Rule)))
+    include Ruleable
 
     getter path : String
     getter schema : Schema?
 
     def initialize(@path : String, @schema : Schema? = nil)
-      @rules = RuleMap.new
     end
-
-    # --- Rule registration API (symbol-friendly) ---
-
-    # overload for single method
-    def before(rule : Rule, only : ServiceMethod | Symbol) : self
-      before(rule, only: [only])
-    end
-
-    def after(rule : Rule, only : ServiceMethod | Symbol) : self
-      after(rule, only: [only])
-    end
-
-    # existing array version (unchanged, except it now also accepts symbols)
-    def before(rule : Rule, only : Array(ServiceMethod | Symbol) = [] of ServiceMethod) : self
-      methods = only.map { |m| m.is_a?(Symbol) ? ServiceMethod.parse(m.to_s.capitalize) : m }
-      register_rule(RulePhase::Before, methods, rule)
-      self
-    end
-
-    def after(rule : Rule, only : Array(ServiceMethod | Symbol) = [] of ServiceMethod) : self
-      methods = only.map { |m| m.is_a?(Symbol) ? ServiceMethod.parse(m.to_s.capitalize) : m }
-      register_rule(RulePhase::After, methods, rule)
-      self
-    end
-
-    # --- Abstract service methods ---
 
     abstract def find(ctx : RuleContext) : Array(Hash(String, AnyData))
     abstract def get(ctx : RuleContext) : Hash(String, AnyData)?
@@ -42,51 +15,41 @@ module Alumna
     abstract def patch(ctx : RuleContext) : Hash(String, AnyData)
     abstract def remove(ctx : RuleContext) : Bool
 
-    # --- Full request lifecycle ---
-
     def dispatch(ctx : RuleContext) : RuleContext
-      # 1. Before rules
-      run_rules(ctx, collect_rules(ctx.method, RulePhase::Before))
-      return ctx if ctx.error || ctx.result_set?
+      # 1. before
+      Orchestrator.run(collect_rules(ctx.method, RulePhase::Before), ctx)
+      return ctx if ctx.error
 
-      # 2. Service method call
-      ctx.phase = RulePhase::After
-      result, error = call_method(ctx)
-      if error
-        ctx.error = error
-        ctx.phase = RulePhase::Error
-        return ctx
+      # 2. service method — only if no result yet
+      unless ctx.result_set?
+        ctx.phase = RulePhase::After
+        result, error = call_method(ctx)
+        if error
+          ctx.error = error
+          ctx.phase = RulePhase::Error
+          return ctx
+        end
+        ctx.result = result
       end
-      ctx.result = result
 
-      # 3. After rules
-      run_rules(ctx, collect_rules(ctx.method, RulePhase::After))
+      # 3. after — always runs on success, even on short-circuit
+      ctx.phase = RulePhase::After
+      Orchestrator.run(collect_rules(ctx.method, RulePhase::After), ctx)
       ctx
     end
 
-    # --- Private ---
-
-    # Returns the result and nil error on success, or nil result and a
-    # ServiceError on failure. No exceptions cross this boundary.
     private def call_method(ctx : RuleContext) : {ServiceResult, ServiceError?}
       case ctx.method
-      when .find?
-        {find(ctx), nil}
+      when .find? then {find(ctx), nil}
       when .get?
         result = get(ctx)
         raise ServiceError.not_found unless result
         {result, nil}
-      when .create?
-        {create(ctx), nil}
-      when .update?
-        {update(ctx), nil}
-      when .patch?
-        {patch(ctx), nil}
+      when .create? then {create(ctx), nil}
+      when .update? then {update(ctx), nil}
+      when .patch?  then {patch(ctx), nil}
       when .remove?
-        # remove returns Bool — translate to a minimal result hash
-        removed = remove(ctx)
-        result = {"removed" => removed} of String => AnyData
-        {result, nil}
+        { {"removed" => remove(ctx)} of String => AnyData, nil }
       else
         {nil, ServiceError.internal("Unknown service method")}
       end
@@ -94,25 +57,6 @@ module Alumna
       {nil, ex}
     rescue ex : Exception
       {nil, ServiceError.internal(ex.message || "Unexpected error")}
-    end
-
-    private def run_rules(ctx : RuleContext, rules : Array(Rule))
-      Orchestrator.run(rules, ctx)
-    end
-
-    private def collect_rules(method : ServiceMethod, phase : RulePhase) : Array(Rule)
-      global = @rules[nil]?.try(&.[phase]?) || [] of Rule
-      specific = @rules[method]?.try(&.[phase]?) || [] of Rule
-      global + specific
-    end
-
-    private def register_rule(phase : RulePhase, methods : Array(ServiceMethod), rule : Rule)
-      targets = methods.empty? ? [nil] : methods.map(&.as(ServiceMethod?))
-      targets.each do |target|
-        @rules[target] ||= {} of RulePhase => Array(Rule)
-        @rules[target][phase] ||= [] of Rule
-        @rules[target][phase] << rule
-      end
     end
   end
 end


### PR DESCRIPTION
Now rules can be applied globally to the `app` as well, which automatically covers all services. Both `before` and `after` rules are supported, like in the example below:

```crystal
app.before CORS
app.before RateLimit
app.after Logger
```

**Execution order:**

When a request arrives, now rules run in this exact sequence:

1. `app.before` rules
2. `service.before` rules
3. service method (`find`, `get`, etc.) — skipped if a before-rule set `ctx.result`
4. `service.after` rules
5. `app.after` rules

After-rules always run when there is no error, even if a before-rule short-circuited the service method. This makes logging, metrics, and response headers reliable.

**Broader example**

```crystal
app = Alumna::App.new

# Global rules run for every service
app.before CORS
app.before RateLimit
app.after Logger

app.use("/users", UserService.new)
app.listen(3000)
```