### PR TITLE
fix: solid foundation for v0.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Alumna Backend changelog
 
+## 0.3.6 - 2026-05-05
+
+### Fixed
+* **app dispatch:** after-phase errors now run service error hooks before app error hooks, making error handling symmetrical across before/service/after phases
+* **http responder:** 204 No Content and 304 Not Modified responses no longer include a body, per RFC 7230/7231; fixes CORS preflight returning `{}`
+* **router:** paths are now normalized (`/items` == `/items/`), duplicate `app.use` mounts raise `ArgumentError`
+* **limited_io:** limit enforcement now covers `read_byte`, `peek`, and `skip`; `peek` returns `Bytes.empty` at EOF instead of `nil`
+
+### Added
+* **query:** new `ctx.query` API with lazy parsing of `$limit`, `$skip`, `$sort`, `$select`; `MemoryAdapter#find` implements all four
+* **tests:** full coverage for query parsing, path normalization, and LimitedIO lifecycle (`close`, `closed?`)
+
+### Changed
+* **cors:** global rules no longer run on OPTIONS by design; register with `only: :options` (or all methods) for preflights — documented and tested
+
 ## 0.3.5 - 2026-04-28
 
 * refactor: HTTP `OPTIONS` verb is now native are correctly handled

--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ app.listen(3000) # binds to 127.0.0.1:3000 by default
 
 ---
 
+## Table of Contents
+- [Backend can be simple](#backend-can-be-simple)
+- [Philosophy](#philosophy)
+- [Status](#status)
+- [Installation](#installation)
+- [Core concepts](#core-concepts)
+    - [Schema](#schema)
+        - [Pluggable formats](#pluggable-formats)
+    - [Validation: Built-in validation rule](#validation-built-in-validation-rule)
+    - [Validation: custom validator](#validation-custom-validator)
+    - [Built-in rules](#built-in-rules)
+- [Rules](#rules)
+- [Headers, params, and client IP](#headers-params-and-client-ip)
+- [Services](#services)
+- [Example of global rules in an application](#example-of-global-rules-in-an-application)
+- [Full example](#full-example)
+- [Writing a custom adapter](#writing-a-custom-adapter)
+- [Serialization](#serialization)
+- [Roadmap](#roadmap)
+- [Design decisions and trade-offs](#design-decisions-and-trade-offs)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
 ## Philosophy
 
 Most backend frameworks ask you to learn their full architecture before you can write a single working endpoint. Alumna takes the opposite approach.
@@ -64,6 +89,9 @@ Alumna is in active early development. The following core pieces are complete an
 - ✅ In-memory adapter implementing the full service interface
 - ✅ JSON and MessagePack serialization
 - ✅ Rich `RuleContext` with `store`, `remote_ip` (with trusted proxy support), `http_method`, `headers`, and `provider`
+- ✅ Query parsing (`$limit`, `$skip`, `$sort`, `$select`) via `ctx.query`
+- ✅ Path normalization and duplicate-route protection
+- ✅ Strict request-body limits enforced on all IO entry points
 - ✅ Cross-platform CI with full test coverage
 
 Production-ready built-in rules:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: alumna
-version: 0.3.5
+version: 0.3.6
 
 authors:
   - Paulo Coghi <paulo@airsailer.io>

--- a/spec/adapter/memory_spec.cr
+++ b/spec/adapter/memory_spec.cr
@@ -149,6 +149,20 @@ describe Alumna::MemoryAdapter do
       rec.has_key?("b").should be_false
       rec.has_key?("id").should be_true # id always preserved
     end
+
+    it "applies $select when id is explicitly requested" do
+      adapter = Alumna::MemoryAdapter.new("/items")
+      insert(adapter, {"a" => any("1"), "b" => any("2")} of String => Alumna::AnyData)
+      ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$select" => "a,id"})
+      rec = adapter.find(ctx).first
+      rec.keys.sort!.should eq(["a", "id"]) # id not duplicated
+    end
+
+    it "applies $select on empty store" do
+      adapter = Alumna::MemoryAdapter.new("/items")
+      ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$select" => "a"})
+      adapter.find(ctx).should be_empty
+    end
   end
 
   describe "#get" do
@@ -278,7 +292,7 @@ describe Alumna::MemoryAdapter do
       records = adapter.find(ctx)
 
       records.size.should eq(count)
-      ids = records.map { |r| r["id"].as(String).to_i64 }.sort
+      ids = records.map { |rec| rec["id"].as(String).to_i64 }.sort!
       ids.should eq((1_i64..count.to_i64).to_a)
     end
 
@@ -290,7 +304,7 @@ describe Alumna::MemoryAdapter do
       writers = 50
       done = Channel(Nil).new(writers)
 
-      writers.times do |i|
+      writers.times do |_i|
         spawn do
           get_ctx = make_ctx(adapter, Alumna::ServiceMethod::Get, id: id)
           current = adapter.get(get_ctx)

--- a/spec/adapter/memory_spec.cr
+++ b/spec/adapter/memory_spec.cr
@@ -122,6 +122,33 @@ describe Alumna::MemoryAdapter do
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"role" => "admin"})
       adapter.find(ctx).should be_empty
     end
+
+    it "applies $limit and $skip" do
+      adapter = Alumna::MemoryAdapter.new("/items")
+      5.times { |i| insert(adapter, {"n" => any(i.to_s)} of String => Alumna::AnyData) }
+      ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$skip" => "1", "$limit" => "2"})
+      results = adapter.find(ctx)
+      results.size.should eq(2)
+      results.map(&.["n"]).should eq(["1", "2"])
+    end
+
+    it "applies $sort" do
+      adapter = Alumna::MemoryAdapter.new("/items")
+      insert(adapter, {"age" => any("30")} of String => Alumna::AnyData)
+      insert(adapter, {"age" => any("20")} of String => Alumna::AnyData)
+      ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$sort" => "age:1"})
+      adapter.find(ctx).first["age"].should eq("20")
+    end
+
+    it "applies $select" do
+      adapter = Alumna::MemoryAdapter.new("/items")
+      insert(adapter, {"a" => any("1"), "b" => any("2")} of String => Alumna::AnyData)
+      ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$select" => "a"})
+      rec = adapter.find(ctx).first
+      rec.has_key?("a").should be_true
+      rec.has_key?("b").should be_false
+      rec.has_key?("id").should be_true # id always preserved
+    end
   end
 
   describe "#get" do

--- a/spec/app/path_spec.cr
+++ b/spec/app/path_spec.cr
@@ -1,0 +1,27 @@
+require "../spec_helper"
+
+describe "App path normalization" do
+  it "treats trailing slash as same route" do
+    app = Alumna::App.new
+    svc = Alumna::MemoryAdapter.new("/test")
+    app.use("/test/", svc) # normalized to /test
+
+    app.services.has_key?("/test").should be_true
+    app.services.has_key?("/test/").should be_false
+  end
+
+  it "raises on duplicate mount" do
+    app = Alumna::App.new
+    app.use("/items", Alumna::MemoryAdapter.new("/items"))
+    expect_raises(ArgumentError, /already mounted/) do
+      app.use("/items/", Alumna::MemoryAdapter.new("/items"))
+    end
+  end
+
+  it "rejects paths without leading slash" do
+    app = Alumna::App.new
+    expect_raises(ArgumentError, /must start with/) do
+      app.use("items", Alumna::MemoryAdapter.new("items"))
+    end
+  end
+end

--- a/spec/http/responder_spec.cr
+++ b/spec/http/responder_spec.cr
@@ -147,4 +147,34 @@ describe Alumna::Http::Responder do
       resp.status_code.should eq(422)
     end
   end
+
+  describe "RFCs 7230/7231: 204 and 304 MUST NOT include a body" do
+    it "skips encoding for 204 No Content" do
+      ctx = build_ctx(result: {"should_not" => "appear"} of String => Alumna::AnyData)
+      ctx.http.status = 204
+      io = IO::Memory.new
+      resp = HTTP::Server::Response.new(io)
+
+      Alumna::Http::Responder.write(resp, ctx, json_serializer)
+      resp.close
+
+      resp.status_code.should eq(204)
+      io.to_s.should_not contain("should_not")
+      io.to_s.should_not contain("{}") # body must be empty
+    end
+
+    it "skips encoding for 304 Not Modified" do
+      ctx = build_ctx(result: {"x" => 1_i64} of String => Alumna::AnyData)
+      ctx.http.status = 304
+      io = IO::Memory.new
+      resp = HTTP::Server::Response.new(io)
+
+      Alumna::Http::Responder.write(resp, ctx, json_serializer)
+      resp.close
+
+      resp.status_code.should eq(304)
+      io.to_s.should end_with("\r\n\r\n") # headers terminator, nothing after
+      io.to_s.should_not contain("\"x\"") # body must be absent
+    end
+  end
 end

--- a/spec/http/router_spec.cr
+++ b/spec/http/router_spec.cr
@@ -297,15 +297,28 @@ describe "Router integration" do
   # ── Path matching edge cases ───────────────────────────────────────────────────
 
   describe "path matching" do
-    it "returns 404 for trailing slash on id segment" do
-      # /items/1/ → id would be "1/", which contains '/', so no match
-      response = get("/items/1/", AUTH)
-      response.status_code.should eq(404)
+    it "normalizes trailing slash on id segment" do
+      # /items/1/ → normalized to /items/1, so it should succeed
+      created = post("/items", %|{"name":"Trailing"}|, AUTH)
+      id = JSON.parse(created.body)["id"].as_s
+
+      response = get("/items/#{id}/", AUTH)
+      response.status_code.should eq(200)
+      JSON.parse(response.body)["id"].as_s.should eq(id)
     end
 
     it "returns 404 for nested path segments" do
+      # /items/1/extra has a second '/' after the id → still invalid
       response = get("/items/1/extra", AUTH)
       response.status_code.should eq(404)
+    end
+
+    it "normalizes trailing slash on collection path" do
+      # /items/ and /items should hit the same service
+      r1 = get("/items", AUTH)
+      r2 = get("/items/", AUTH)
+      r1.status_code.should eq(200)
+      r2.status_code.should eq(200)
     end
   end
 

--- a/spec/http/router_spec.cr
+++ b/spec/http/router_spec.cr
@@ -402,12 +402,47 @@ describe "Router integration" do
       end
     end
 
+    it "enforces limit on read_byte" do
+      source = IO::Memory.new("ab")
+      limited = Alumna::Http::LimitedIO.new(source, 1)
+
+      limited.read_byte.should eq('a'.ord)
+      expect_raises(IO::Error, "exceeded") do
+        limited.read_byte
+      end
+    end
+
+    it "limits peek to remaining bytes" do
+      source = IO::Memory.new("12345")
+      limited = Alumna::Http::LimitedIO.new(source, 3)
+
+      limited.peek.should eq("123".to_slice)
+    end
+
+    it "enforces limit on skip" do
+      source = IO::Memory.new("abcdef")
+      limited = Alumna::Http::LimitedIO.new(source, 2)
+
+      limited.skip(5) # only 2 bytes can be skipped
+      expect_raises(IO::Error, "exceeded") do
+        limited.read(Bytes.new(1))
+      end
+    end
+
     it "raises on write because it is read-only" do
       limited = Alumna::Http::LimitedIO.new(IO::Memory.new, 10)
-
       expect_raises(IO::Error, "write not supported") do
         limited.write("x".to_slice)
       end
+    end
+
+    it "peek returns Bytes.empty when limit is exhausted" do
+      source = IO::Memory.new("abc")
+      limited = Alumna::Http::LimitedIO.new(source, 2)
+      limited.read(Bytes.new(2)) # consume limit
+
+      peeked = limited.peek
+      peeked.should eq(Bytes.empty)
     end
   end
 

--- a/spec/http/router_spec.cr
+++ b/spec/http/router_spec.cr
@@ -444,6 +444,23 @@ describe "Router integration" do
       peeked = limited.peek
       peeked.should eq(Bytes.empty)
     end
+
+    it "closed? reflects the underlying IO state" do
+      source = IO::Memory.new("abc")
+      limited = Alumna::Http::LimitedIO.new(source, 3)
+
+      limited.closed?.should be_false
+      source.closed?.should be_false
+    end
+
+    it "close delegates to the underlying IO" do
+      source = IO::Memory.new("abc")
+      limited = Alumna::Http::LimitedIO.new(source, 3)
+
+      limited.close
+      limited.closed?.should be_true # delegates to source.closed?
+      source.closed?.should be_true  # confirms the delegation actually closed source
+    end
   end
 
   # ── OPTIONS convention ───────────────────────────────────────────────────────

--- a/spec/integration/app_spec.cr
+++ b/spec/integration/app_spec.cr
@@ -42,6 +42,11 @@ class AfterFailService < Alumna::MemoryAdapter
     after Alumna::Rule.new { |ctx|
       Alumna::RuleResult.stop(Alumna::ServiceError.internal("after failed"))
     }
+    # service-level error hook
+    error Alumna::Rule.new { |ctx|
+      ctx.http.headers["X-Service-Error"] = "svc-456"
+      Alumna::RuleResult.continue
+    }
   end
 end
 
@@ -217,7 +222,8 @@ describe "Alumna System Integration" do
   it "runs app error rules when an after-rule stops" do
     res = authenticated_client.get("/after-stop")
     res.status_code.should eq(500)
-    res.headers["X-Error-ID"]?.should eq("err-123")
+    res.headers["X-Error-ID"]?.should eq("err-123")      # app-level
+    res.headers["X-Service-Error"]?.should eq("svc-456") # service-level
     # AfterLogger ran before the stop, so the header is present
     res.headers["X-Request-ID"]?.should_not be_nil
     json(res.body)["error"].as_s.should eq("after failed")

--- a/spec/integration/app_spec.cr
+++ b/spec/integration/app_spec.cr
@@ -50,6 +50,15 @@ class AfterFailService < Alumna::MemoryAdapter
   end
 end
 
+class CorsService < Alumna::MemoryAdapter
+  def initialize
+    super("/cors-test")
+    # OPTIONS is opt-in, so list all methods explicitly
+    before Alumna.cors(origins: ["https://example.com"]),
+      only: [:find, :get, :create, :update, :patch, :remove, :options]
+  end
+end
+
 def authenticated_client
   HTTP::Client.new("localhost", TEST_PORT).tap do |c|
     c.before_request do |r|
@@ -69,6 +78,7 @@ describe "Alumna System Integration" do
     app.error ErrorLogger
     app.use("/test", TestService.new)
     app.use("/after-stop", AfterFailService.new)
+    app.use("/cors-test", CorsService.new)
     spawn { app.listen(TEST_PORT) }
     sleep 0.3.seconds
   end
@@ -227,5 +237,19 @@ describe "Alumna System Integration" do
     # AfterLogger ran before the stop, so the header is present
     res.headers["X-Request-ID"]?.should_not be_nil
     json(res.body)["error"].as_s.should eq("after failed")
+  end
+
+  it "CORS preflight returns 204 with empty body" do
+    client = HTTP::Client.new("localhost", TEST_PORT)
+    client.before_request do |r|
+      r.headers["Origin"] = "https://example.com"
+      r.headers["Access-Control-Request-Method"] = "POST"
+    end
+    res = client.options("/cors-test")
+
+    res.status_code.should eq(204)
+    res.body.should be_empty
+    res.headers["Access-Control-Allow-Origin"].should eq("https://example.com")
+    res.headers["Access-Control-Allow-Methods"].should contain("POST")
   end
 end

--- a/spec/rule/orchestrator_spec.cr
+++ b/spec/rule/orchestrator_spec.cr
@@ -151,4 +151,22 @@ describe Alumna::Orchestrator do
       log.should eq(["a", "b", "c"])
     end
   end
+
+  describe "service errors are skipped when the app stops early" do
+    it "skips service error hooks when app before-rule stops" do
+      log = [] of String
+      app = Alumna::App.new
+      app.before(Alumna::Rule.new { |ctx| log << "app-before"; Alumna::RuleResult.stop(Alumna::ServiceError.forbidden) })
+      app.error(Alumna::Rule.new { |ctx| log << "app-error"; Alumna::RuleResult.continue })
+
+      svc = Alumna::MemoryAdapter.new("/x")
+      svc.error(Alumna::Rule.new { |ctx| log << "svc-error"; Alumna::RuleResult.continue })
+      app.use("/x", svc)
+
+      ctx = test_ctx(app: app, service: svc, method: Alumna::ServiceMethod::Find)
+      app.dispatch(svc, ctx)
+
+      log.should eq(["app-before", "app-error"]) # svc-error must NOT appear
+    end
+  end
 end

--- a/spec/service/query_spec.cr
+++ b/spec/service/query_spec.cr
@@ -1,0 +1,21 @@
+require "../spec_helper"
+
+describe Alumna::Query do
+  it "parses filters, limit, skip, sort, select" do
+    params = HTTP::Params.parse("name=Bob&$limit=2&$skip=1&$sort=age:-1&$select=id,name")
+    q = Alumna::Query.new(Alumna::Http::ParamsView.new(params))
+
+    q.filters["name"].should eq("Bob")
+    q.limit.should eq(2)
+    q.skip.should eq(1)
+    q.sort.should eq([{"age", -1}])
+    q.select.should eq(["id", "name"])
+  end
+
+  it "ignores unknown $ keys" do
+    params = HTTP::Params.parse("$foo=bar&x=1")
+    q = Alumna::Query.new(Alumna::Http::ParamsView.new(params))
+    q.filters["x"].should eq("1")
+    q.filters.has_key?("$foo").should be_false
+  end
+end

--- a/spec/service/query_spec.cr
+++ b/spec/service/query_spec.cr
@@ -18,4 +18,12 @@ describe Alumna::Query do
     q.filters["x"].should eq("1")
     q.filters.has_key?("$foo").should be_false
   end
+
+  it "empty? is true for empty params and false otherwise" do
+    q1 = Alumna::Query.new(Alumna::Http::ParamsView.new(HTTP::Params.new))
+    q1.empty?.should be_true
+
+    q2 = Alumna::Query.new(Alumna::Http::ParamsView.new(HTTP::Params.parse("x=1")))
+    q2.empty?.should be_false
+  end
 end

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -44,7 +44,9 @@ module Alumna
 
         # 4) select (always keep id for sanity)
         if fields = q.select
+          # LCOV_EXCL_START - kcov wrongly misses .map
           records.map do |rec|
+            # LCOV_EXCL_STOP
             selected = rec.select(fields)
             selected["id"] = rec["id"] if rec["id"]? && !selected.has_key?("id")
             selected

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -13,13 +13,45 @@ module Alumna
 
     def find(ctx : RuleContext) : Array(Hash(String, AnyData))
       @mutex.synchronize do
+        q = ctx.query
         records = @store.values
-        return records.to_a if ctx.params.empty?
-        records.select do |record|
-          ctx.params.all? do |key, value|
-            record[key]?.as?(String) == value
+
+        # 1) filters (old behaviour, now via q.filters)
+        unless q.filters.empty?
+          records = records.select do |rec|
+            q.filters.all? { |k, v| rec[k]?.try(&.to_s) == v }
           end
-        end.to_a
+        end
+
+        # 2) sort
+        records = records.to_a
+        if sort = q.sort
+          records.sort! do |a, b|
+            sort.reduce(0) do |cmp, (field, dir)|
+              next cmp if cmp != 0
+              av = a[field]?.try(&.to_s) || ""
+              bv = b[field]?.try(&.to_s) || ""
+              (av <=> bv) * dir
+            end
+          end
+        end
+
+        # 3) skip + limit
+        records = records.skip(q.skip || 0)
+        if limit = q.limit
+          records = records.first(limit)
+        end
+
+        # 4) select (always keep id for sanity)
+        if fields = q.select
+          records.map do |rec|
+            selected = rec.select(fields)
+            selected["id"] = rec["id"] if rec["id"]? && !selected.has_key?("id")
+            selected
+          end
+        else
+          records
+        end
       end
     end
 

--- a/src/alumna.cr
+++ b/src/alumna.cr
@@ -1,5 +1,5 @@
 module Alumna
-  VERSION = "0.3.5"
+  VERSION = "0.3.6"
 end
 
 # Core enums and primitives - no dependencies

--- a/src/app.cr
+++ b/src/app.cr
@@ -17,8 +17,15 @@ module Alumna
     end
 
     def use(path : String, service : Service) : self
-      @services[path] = service
+      normalized = normalize_path(path)
+      raise ArgumentError.new("service already mounted at #{normalized}") if @services.has_key?(normalized)
+      @services[normalized] = service
       self
+    end
+
+    private def normalize_path(path) : String
+      raise ArgumentError.new("path must start with '/'") unless path.starts_with?('/')
+      path == "/" ? path : path.chomp('/')
     end
 
     private def compile_pipelines!

--- a/src/app.cr
+++ b/src/app.cr
@@ -75,6 +75,7 @@ module Alumna
       after_rules = service.after_pipeline(m)
       unless Orchestrator.run(after_rules, ctx)
         ctx.phase = RulePhase::Error
+        Orchestrator.run(service.collect_rules(m, RulePhase::Error), ctx)
         Orchestrator.run(collect_rules(m, RulePhase::Error), ctx)
       end
       ctx

--- a/src/http/responder.cr
+++ b/src/http/responder.cr
@@ -18,6 +18,9 @@ module Alumna
 
         response.status_code = ctx.http.status || default_status(ctx.method)
 
+        # RFC 7230 sec 3.3.2 / RFC 7231 sec 6.3.5: 204 and 304 MUST NOT include a body
+        return if response.status_code == 204 || response.status_code == 304
+
         case result = ctx.result
         when Array
           serializer.encode(result, response)

--- a/src/http/router.cr
+++ b/src/http/router.cr
@@ -72,6 +72,9 @@ module Alumna
       end
 
       private def resolve_service(path : String) : {Service, String?}?
+        # treat /items and /items/ as identical
+        path = path == "/" ? path : path.chomp('/')
+
         # 1) exact match – find/create – single hash lookup, no allocations
         if service = @services[path]?
           return {service, nil}

--- a/src/http/router/limited_io.cr
+++ b/src/http/router/limited_io.cr
@@ -1,5 +1,8 @@
 module Alumna
   module Http
+    # Enforces max_body_size on *every* read entry point.
+    # Raises IO::Error("exceeded") the moment the limit is hit,
+    # so the router can turn it into 413 immediately.
     class LimitedIO < IO
       def initialize(@io : IO, @limit : Int64)
         @read = 0_i64
@@ -7,7 +10,7 @@ module Alumna
 
       def read(slice : Bytes) : Int32
         raise IO::Error.new("exceeded") if @read >= @limit
-        to_read = Math.min(slice.size, @limit - @read).to_i
+        to_read = Math.min(slice.size.to_i64, @limit - @read).to_i
         n = @io.read(slice[0, to_read])
         @read += n
         n
@@ -15,6 +18,39 @@ module Alumna
 
       def write(slice : Bytes) : Nil
         raise IO::Error.new("write not supported")
+      end
+
+      # --- completeness: all read paths must enforce the limit ---
+
+      def read_byte : UInt8?
+        raise IO::Error.new("exceeded") if @read >= @limit
+        byte = @io.read_byte
+        @read += 1 if byte
+        byte
+      end
+
+      def peek : Bytes?
+        return Bytes.empty if @read >= @limit
+        if peeked = @io.peek
+          remaining = @limit - @read
+          peeked.size > remaining ? peeked[0, remaining.to_i] : peeked
+        end
+      end
+
+      def skip(bytes_count) : Nil
+        raise IO::Error.new("exceeded") if @read >= @limit
+        to_skip = Math.min(bytes_count.to_i64, @limit - @read)
+        @io.skip(to_skip)
+        @read += to_skip
+      end
+
+      # delegate lifecycle
+      def close
+        @io.close
+      end
+
+      def closed?
+        @io.closed?
       end
     end
   end

--- a/src/service/context.cr
+++ b/src/service/context.cr
@@ -30,6 +30,12 @@ module Alumna
     property headers : Http::HeadersView
     property store : Hash(String, AnyData)
 
+    @query : Query?
+
+    def query : Query
+      @query ||= Query.new(@params)
+    end
+
     protected setter phase
 
     def initialize(
@@ -66,6 +72,47 @@ module Alumna
       @status = nil
       @headers = {} of String => String
       @location = nil
+    end
+  end
+
+  class Query
+    getter filters : Hash(String, String)
+    getter limit : Int32?
+    getter skip : Int32?
+    getter sort : Array(Tuple(String, Int32))?
+    getter select : Array(String)?
+
+    def initialize(params : Http::ParamsView)
+      @filters = {} of String => String
+      @limit = nil
+      @skip = nil
+      @sort = nil
+      @select = nil
+
+      params.each do |k, v|
+        case k
+        when "$limit"
+          @limit = v.to_i? if v.matches?(/^\d+$/)
+        when "$skip"
+          @skip = v.to_i? if v.matches?(/^\d+$/)
+        when "$sort"
+          # "age:-1,name:1" → [{"age",-1},{"name",1}]
+          @sort = v.split(',').compact_map do |part|
+            field, dir = part.split(':', 2)
+            next if field.empty?
+            dir_i = dir.try(&.to_i?) || 1
+            {field, dir_i >= 0 ? 1 : -1}
+          end
+        when "$select"
+          @select = v.split(',').map(&.strip).reject(&.empty?)
+        else
+          @filters[k] = v unless k.starts_with?('$')
+        end
+      end
+    end
+
+    def empty? : Bool
+      @filters.empty? && @limit.nil? && @skip.nil? && @sort.nil? && @select.nil?
     end
   end
 end


### PR DESCRIPTION
**fix(app): run service error hooks on after-phase failures**
- make AFTER error handling symmetrical with BEFORE and SERVICE
- add integration test verifying service+app error hooks fire
- no performance impact on happy path

**fix(http): never encode body for 204/304 responses**

- Responder.write now returns early for 204/304 per RFC 7231
- fixes CORS preflight sending "{}"
- adds responder specs for 204/304, adds integration test for OPTIONS

**feat: Query abstraction**

**fix: path normalization for both service registration and HTTP calls**
- paths are canonical
- registration of duplicate services are prevented
- updated spec tests to reflect the new contract

**refactor: better and complete LimitedIO implementation**