### PR TITLE
refactor: simplifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class MessageService < Alumna::MemoryAdapter
   def initialize
     super(MessageSchema)
     before Authenticate
-    before Alumna.validate(MessageSchema), only: [:create, :update]
+    before Alumna.validate(MessageSchema), on: :write
   end
 end
 
@@ -220,7 +220,7 @@ Because it receives `ctx.method`, it automatically respects `required_on: [:crea
 class UserService < Alumna::MemoryAdapter
   def initialize
     super(UserSchema)
-    before Alumna.validate(UserSchema), only: [:create, :update, :patch]
+    before Alumna.validate(UserSchema), on: :write
   end
 end
 ```
@@ -248,7 +248,7 @@ Alumna.rate_limit(limit: 100, window_seconds: 60) # in-memory rate limiting
 
 **1. Validation**
 ```crystal
-before Alumna.validate(UserSchema), only: [:create, :update, :patch]
+before Alumna.validate(UserSchema), on: :write
 ```
 Returns 422 with per-field details when validation fails. Respects `required_on`.
 
@@ -257,12 +257,12 @@ Returns 422 with per-field details when validation fails. Respects `required_on`
 # for normal requests
 before Alumna.cors(origins: ["https://app.example.com"])
 # for preflights — OPTIONS is opt-in by design
-before Alumna.cors(origins: ["https://app.example.com"]), only: :options
+before Alumna.cors(origins: ["https://app.example.com"]), on: :options
 ```
 - Sets `Access-Control-Allow-Origin`, `Vary: Origin`, and credentials when enabled
 - Handles real preflights (`OPTIONS` + `Access-Control-Request-Method`) with 204
 - `origins: ["*"]` is allowed for public APIs, but using it with `credentials: true` raises `ArgumentError` at boot — per the Fetch spec, wildcard cannot be used with credentials
-- **Convention:** global `before` rules do *not* run on `OPTIONS` unless you explicitly include `only: :options`. This prevents authentication or validation from blocking CORS preflights, matching the HTTP spec.
+- **Convention:** global `before` rules do *not* run on `OPTIONS` unless you explicitly include `on: :options`. This prevents authentication or validation from blocking CORS preflights, matching the HTTP spec.
 
 **3. Logger**
 ```crystal
@@ -287,7 +287,7 @@ before Alumna.rate_limit(limit: 60, window_seconds: 60)
 - Returns 429 when exceeded
 - Skips `OPTIONS` requests automatically
 
-All four are regular `Rule` objects - you can compose them with your own rules, limit them with `only:`, and test them with `RuleRunner` like any custom rule.
+All four are regular `Rule` objects - you can compose them with your own rules, limit them with `on:`, and test them with `RuleRunner` like any custom rule.
 
 ---
 
@@ -430,7 +430,7 @@ class UserService < Alumna::MemoryAdapter
   def initialize
     super(UserSchema)
     before Authenticate
-    before Alumna.validate(UserSchema), only: [:create, :update, :patch]
+    before Alumna.validate(UserSchema), on: :write
     after AddRequestId
     error LogError
   end
@@ -509,7 +509,7 @@ class UserService < Alumna::MemoryAdapter
   def initialize
     super(UserSchema)
     before Authenticate
-    before Alumna.validate(UserSchema), only: [:create, :update, :patch]
+    before Alumna.validate(UserSchema), on: :write
   end
 end
 
@@ -517,7 +517,7 @@ class PostService < Alumna::MemoryAdapter
   def initialize
     super(PostSchema)
     before Authenticate
-    before Alumna.validate(PostSchema), only: [:create, :update, :patch]
+    before Alumna.validate(PostSchema), on: :write
 
   end
 end

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ end
 # Built-in adapters
 class MessageService < Alumna::MemoryAdapter
   def initialize
-    super("/messages", MessageSchema)
+    super(MessageSchema)
     before Authenticate
     before Alumna.validate(MessageSchema), only: [:create, :update]
   end
@@ -219,7 +219,7 @@ Because it receives `ctx.method`, it automatically respects `required_on: [:crea
 ```crystal
 class UserService < Alumna::MemoryAdapter
   def initialize
-    super("/users", UserSchema)
+    super(UserSchema)
     before Alumna.validate(UserSchema), only: [:create, :update, :patch]
   end
 end
@@ -428,7 +428,7 @@ A service inherits from `Alumna::MemoryAdapter` (or from `Alumna::Service` direc
 ```crystal
 class UserService < Alumna::MemoryAdapter
   def initialize
-    super("/users", UserSchema)
+    super(UserSchema)
     before Authenticate
     before Alumna.validate(UserSchema), only: [:create, :update, :patch]
     after AddRequestId
@@ -507,7 +507,7 @@ end
 
 class UserService < Alumna::MemoryAdapter
   def initialize
-    super("/users", UserSchema)
+    super(UserSchema)
     before Authenticate
     before Alumna.validate(UserSchema), only: [:create, :update, :patch]
   end
@@ -515,7 +515,7 @@ end
 
 class PostService < Alumna::MemoryAdapter
   def initialize
-    super("/posts", PostSchema)
+    super(PostSchema)
     before Authenticate
     before Alumna.validate(PostSchema), only: [:create, :update, :patch]
 
@@ -539,7 +539,7 @@ To connect a real database, inherit from `Alumna::Service` and implement the six
 ```crystal
 class PostgresUserService < Alumna::Service
   def initialize(@db : DB::Database)
-    super("/users", UserSchema)
+    super(UserSchema)
     self.before(Authenticate)
   end
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ require "alumna"
 
 # Schema definition
 MessageSchema = Alumna::Schema.new
-  .str("body", required: true, min_length: 1, max_length: 500)
-  .str("author", required: true, min_length: 1)
+  .str("body", min_length: 1, max_length: 500)
+  .str("author", min_length: 1)
   .bool("read", required: false)
 
 # Authentication rule
 Authenticate = Alumna::Rule.new do |ctx|
   token = ctx.headers["authorization"]?
-  token == "Bearer my-secret" ? Alumna::RuleResult.continue : Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized)
+  token == "Bearer my-secret" ? nil : Alumna::ServiceError.unauthorized
 end
 
 # Built-in adapters
@@ -208,9 +208,9 @@ It’s equivalent to:
 ```crystal
 Alumna::Rule.new do |ctx|
   errors = UserSchema.validate(ctx.data, ctx.method)
-  next Alumna::RuleResult.continue if errors.empty?
+  next nil if errors.empty?
   details = errors.to_h { |e| {e.field, e.message} }
-  Alumna::RuleResult.stop(Alumna::ServiceError.unprocessable("Validation failed", details))
+  Alumna::ServiceError.unprocessable("Validation failed", details)
 end
 ```
 
@@ -293,26 +293,26 @@ All four are regular `Rule` objects - you can compose them with your own rules, 
 
 ### Rules
 
-A rule is a `Proc` that receives a `RuleContext` and returns a `RuleResult`. Rules are values, not classes - they are defined once and registered globally on the application or on individual services.
+A rule is a `Proc` that receives a `RuleContext` and returns a `nil` to continue and a `ServiceError` to stop. Rules are values, not classes - they are defined once and registered globally on the application or on individual services.
 
 ```crystal
 # A rule that checks for a valid bearer token
 Authenticate = Alumna::Rule.new do |ctx|
   token = ctx.headers["authorization"]?
-  token == "Bearer my-secret" ? Alumna::RuleResult.continue : Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized)
+  token == "Bearer my-secret" ? nil : Alumna::ServiceError.unauthorized
 end
 
 # An after-rule that adds a response header
 AddRequestId = Alumna::Rule.new do |ctx|
   ctx.http.headers["X-Request-ID"] = Random::Secure.hex(8)
-  Alumna::RuleResult.continue
+  nil
 end
 
 # An error-rule that logs failures
 LogError = Alumna::Rule.new do |ctx|
   Log.error { "Request failed: #{ctx.error.message}" } if ctx.error
   ctx.http.headers["X-Error-ID"] = Random::Secure.hex(4)
-  Alumna::RuleResult.continue
+  nil
 end
 ```
 
@@ -401,9 +401,9 @@ Parsing follows the standard order: `Forwarded` → `X-Forwarded-For` → `X-Rea
 **Signalling outcomes:**
 
 ```crystal
-RuleResult.continue                              # proceed to the next rule or service method
-RuleResult.stop(ServiceError.unauthorized)       # halt the pipeline and return an error response
-RuleResult.stop(ServiceError.bad_request("...")) # halt with a custom error
+nil                             # proceed to the next rule or service method
+ServiceError.unauthorized       # halt the pipeline and return an error response
+ServiceError.bad_request("...") # halt with a custom error
 ```
 
 **Available `ServiceError` constructors:**
@@ -460,7 +460,7 @@ When a request arrives, rules run in this exact sequence:
 4. `service.after` rules
 5. `app.after` rules
 
-If any rule returns `RuleResult.stop`, the pipeline jumps immediately to error rules:
+If any rule returns a `ServiceError`, the pipeline jumps immediately to error rules:
 
 6. `service.error` rules
 7. `app.error` rules
@@ -502,7 +502,7 @@ PostSchema = Alumna::Schema.new
 
 Authenticate = Alumna::Rule.new do |ctx|
   token = ctx.headers["authorization"]?
-  token == "Bearer my-secret" ? Alumna::RuleResult.continue : Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized)
+  token == "Bearer my-secret" ? nil : Alumna::ServiceError.unauthorized
 end
 
 class UserService < Alumna::MemoryAdapter

--- a/examples/messages.cr
+++ b/examples/messages.cr
@@ -7,16 +7,12 @@ MessageSchema = Alumna::Schema.new
 
 Authenticate = Alumna::Rule.new do |ctx|
   token = ctx.headers["authorization"]?
-  if token == "secret-token"
-    Alumna::RuleResult.continue
-  else
-    Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized("Invalid or missing token"))
-  end
+  token == "secret-token" ? nil : Alumna::ServiceError.unauthorized("Invalid or missing token")
 end
 
 LogResult = Alumna::Rule.new do |ctx|
   puts "[#{ctx.method}] #{ctx.path} → #{ctx.http.status || 200}"
-  Alumna::RuleResult.continue
+  nil
 end
 
 class MessageService < Alumna::MemoryAdapter

--- a/examples/messages.cr
+++ b/examples/messages.cr
@@ -21,7 +21,7 @@ end
 
 class MessageService < Alumna::MemoryAdapter
   def initialize
-    super("/messages", MessageSchema)
+    super(MessageSchema)
     before Authenticate
     before Alumna.validate(MessageSchema), only: [:create, :update, :patch]
     after LogResult

--- a/examples/messages.cr
+++ b/examples/messages.cr
@@ -1,8 +1,8 @@
 require "../src/alumna"
 
 MessageSchema = Alumna::Schema.new
-  .str("body", required: true, min_length: 1, max_length: 500)
-  .str("author", required: true, min_length: 1)
+  .str("body", min_length: 1, max_length: 500)
+  .str("author", min_length: 1)
   .bool("read", required: false)
 
 Authenticate = Alumna::Rule.new do |ctx|
@@ -19,7 +19,7 @@ class MessageService < Alumna::MemoryAdapter
   def initialize
     super(MessageSchema)
     before Authenticate
-    before Alumna.validate(MessageSchema), only: [:create, :update, :patch]
+    before Alumna.validate(MessageSchema), on: :write
     after LogResult
   end
 end

--- a/examples/user-posts.cr
+++ b/examples/user-posts.cr
@@ -18,7 +18,7 @@ class UserService < Alumna::MemoryAdapter
   def initialize
     super(UserSchema)
     before Authenticate
-    before Alumna.validate(UserSchema), only: [:create, :update, :patch]
+    before Alumna.validate(UserSchema), on: :write
   end
 end
 
@@ -26,7 +26,7 @@ class PostService < Alumna::MemoryAdapter
   def initialize
     super(PostSchema)
     before Authenticate
-    before Alumna.validate(PostSchema), only: [:create, :update, :patch]
+    before Alumna.validate(PostSchema), on: :write
   end
 end
 

--- a/examples/user-posts.cr
+++ b/examples/user-posts.cr
@@ -16,7 +16,7 @@ end
 
 class UserService < Alumna::MemoryAdapter
   def initialize
-    super("/users", UserSchema)
+    super(UserSchema)
     before Authenticate
     before Alumna.validate(UserSchema), only: [:create, :update, :patch]
   end
@@ -24,7 +24,7 @@ end
 
 class PostService < Alumna::MemoryAdapter
   def initialize
-    super("/posts", PostSchema)
+    super(PostSchema)
     before Authenticate
     before Alumna.validate(PostSchema), only: [:create, :update, :patch]
   end

--- a/examples/user-posts.cr
+++ b/examples/user-posts.cr
@@ -11,7 +11,7 @@ PostSchema = Alumna::Schema.new
 
 Authenticate = Alumna::Rule.new do |ctx|
   token = ctx.headers["authorization"]?
-  token == "Bearer my-secret" ? Alumna::RuleResult.continue : Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized)
+  token == "Bearer my-secret" ? nil : Alumna::ServiceError.unauthorized
 end
 
 class UserService < Alumna::MemoryAdapter

--- a/spec/adapter/memory_spec.cr
+++ b/spec/adapter/memory_spec.cr
@@ -45,7 +45,7 @@ end
 describe Alumna::MemoryAdapter do
   describe "#create" do
     it "returns the record with an auto-assigned id" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Create, data: {"name" => any("Alice")} of String => Alumna::AnyData)
       record = adapter.create(ctx)
       record["id"].should eq("1")
@@ -53,7 +53,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "auto-increments ids across successive calls" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       r1 = insert(adapter, {"x" => any("a")} of String => Alumna::AnyData)
       r2 = insert(adapter, {"x" => any("b")} of String => Alumna::AnyData)
       r1["id"].should eq("1")
@@ -61,14 +61,14 @@ describe Alumna::MemoryAdapter do
     end
 
     it "overrides any id supplied in the input data with its own counter" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Create, data: {"id" => any("999"), "name" => any("Bob")} of String => Alumna::AnyData)
       record = adapter.create(ctx)
       record["id"].should eq("1")
     end
 
     it "persists the record so it can be retrieved afterwards" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice")} of String => Alumna::AnyData)
       get_ctx = make_ctx(adapter, Alumna::ServiceMethod::Get, id: "1")
       record = adapter.get(get_ctx)
@@ -81,13 +81,13 @@ describe Alumna::MemoryAdapter do
 
   describe "#find" do
     it "returns an empty array when the store is empty" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find)
       adapter.find(ctx).should be_empty
     end
 
     it "returns all records when no params are given" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice")} of String => Alumna::AnyData)
       insert(adapter, {"name" => any("Bob")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find)
@@ -95,7 +95,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "filters records by a single query param" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"role" => any("admin")} of String => Alumna::AnyData)
       insert(adapter, {"role" => any("user")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"role" => "admin"})
@@ -105,7 +105,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "applies AND semantics when multiple params are given" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"role" => any("admin"), "active" => any("true")} of String => Alumna::AnyData)
       insert(adapter, {"role" => any("admin"), "active" => any("false")} of String => Alumna::AnyData)
       insert(adapter, {"role" => any("user"), "active" => any("true")} of String => Alumna::AnyData)
@@ -117,14 +117,14 @@ describe Alumna::MemoryAdapter do
     end
 
     it "returns an empty array when no records match the filter" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"role" => any("user")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"role" => "admin"})
       adapter.find(ctx).should be_empty
     end
 
     it "applies $limit and $skip" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       5.times { |i| insert(adapter, {"n" => any(i.to_s)} of String => Alumna::AnyData) }
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$skip" => "1", "$limit" => "2"})
       results = adapter.find(ctx)
@@ -133,7 +133,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "applies $sort" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"age" => any("30")} of String => Alumna::AnyData)
       insert(adapter, {"age" => any("20")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$sort" => "age:1"})
@@ -141,7 +141,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "applies $select" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"a" => any("1"), "b" => any("2")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$select" => "a"})
       rec = adapter.find(ctx).first
@@ -151,7 +151,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "applies $select when id is explicitly requested" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"a" => any("1"), "b" => any("2")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$select" => "a,id"})
       rec = adapter.find(ctx).first
@@ -159,7 +159,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "applies $select on empty store" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Find, params: {"$select" => "a"})
       adapter.find(ctx).should be_empty
     end
@@ -167,7 +167,7 @@ describe Alumna::MemoryAdapter do
 
   describe "#get" do
     it "returns the record for a known id" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Get, id: "1")
       record = adapter.get(ctx)
@@ -178,13 +178,13 @@ describe Alumna::MemoryAdapter do
     end
 
     it "returns nil for an unknown id" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Get, id: "99")
       adapter.get(ctx).should be_nil
     end
 
     it "returns nil when ctx.id is nil" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Get, id: nil)
       adapter.get(ctx).should be_nil
     end
@@ -192,7 +192,7 @@ describe Alumna::MemoryAdapter do
 
   describe "#update" do
     it "replaces the record entirely and returns it with the same id" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice"), "role" => any("user")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Update, id: "1", data: {"name" => any("Alice"), "role" => any("admin")} of String => Alumna::AnyData)
       record = adapter.update(ctx)
@@ -203,7 +203,7 @@ describe Alumna::MemoryAdapter do
 
   describe "#patch" do
     it "merges fields and preserves id" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice"), "role" => any("user")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Patch, id: "1", data: {"role" => any("admin")} of String => Alumna::AnyData)
       record = adapter.patch(ctx)
@@ -213,7 +213,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "persists the merge so a subsequent get reflects it" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice"), "role" => any("user")} of String => Alumna::AnyData)
       patch_ctx = make_ctx(adapter, Alumna::ServiceMethod::Patch, id: "1", data: {"role" => any("admin")} of String => Alumna::AnyData)
       adapter.patch(patch_ctx)
@@ -227,14 +227,14 @@ describe Alumna::MemoryAdapter do
     end
 
     it "raises a 404 error when the id does not exist" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Patch, id: "99", data: {"name" => any("Ghost")} of String => Alumna::AnyData)
       error = expect_raises(Alumna::ServiceError) { adapter.patch(ctx) }
       error.status.should eq(404)
     end
 
     it "raises a 400 error when ctx.id is nil" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Patch, id: nil, data: {"name" => any("Ghost")} of String => Alumna::AnyData)
       error = expect_raises(Alumna::ServiceError) { adapter.patch(ctx) }
       error.status.should eq(400)
@@ -243,14 +243,14 @@ describe Alumna::MemoryAdapter do
 
   describe "#remove" do
     it "deletes the record and returns true" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice")} of String => Alumna::AnyData)
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Remove, id: "1")
       adapter.remove(ctx).should be_true
     end
 
     it "makes the record unretrievable after deletion" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       insert(adapter, {"name" => any("Alice")} of String => Alumna::AnyData)
       remove_ctx = make_ctx(adapter, Alumna::ServiceMethod::Remove, id: "1")
       adapter.remove(remove_ctx)
@@ -259,13 +259,13 @@ describe Alumna::MemoryAdapter do
     end
 
     it "returns false when the id does not exist" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Remove, id: "99")
       adapter.remove(ctx).should be_false
     end
 
     it "raises a 400 error when ctx.id is nil" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       ctx = make_ctx(adapter, Alumna::ServiceMethod::Remove, id: nil)
       error = expect_raises(Alumna::ServiceError) { adapter.remove(ctx) }
       error.status.should eq(400)
@@ -274,7 +274,7 @@ describe Alumna::MemoryAdapter do
 
   describe "concurrency" do
     it "assigns unique sequential ids under concurrent creates" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       count = 100
       done = Channel(Nil).new(count)
 
@@ -297,7 +297,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "does not lose updates under concurrent patches to the same record" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       base = insert(adapter, {"counter" => any(0_i64)} of String => Alumna::AnyData)
       id = base["id"].as(String)
 
@@ -336,7 +336,7 @@ describe Alumna::MemoryAdapter do
     end
 
     it "allows concurrent finds while writing" do
-      adapter = Alumna::MemoryAdapter.new("/items")
+      adapter = Alumna::MemoryAdapter.new
       done = Channel(Nil).new(2)
 
       spawn do

--- a/spec/app/path_spec.cr
+++ b/spec/app/path_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe "App path normalization" do
   it "treats trailing slash as same route" do
     app = Alumna::App.new
-    svc = Alumna::MemoryAdapter.new("/test")
+    svc = Alumna::MemoryAdapter.new
     app.use("/test/", svc) # normalized to /test
 
     app.services.has_key?("/test").should be_true
@@ -12,16 +12,16 @@ describe "App path normalization" do
 
   it "raises on duplicate mount" do
     app = Alumna::App.new
-    app.use("/items", Alumna::MemoryAdapter.new("/items"))
+    app.use("/items", Alumna::MemoryAdapter.new)
     expect_raises(ArgumentError, /already mounted/) do
-      app.use("/items/", Alumna::MemoryAdapter.new("/items"))
+      app.use("/items/", Alumna::MemoryAdapter.new)
     end
   end
 
   it "rejects paths without leading slash" do
     app = Alumna::App.new
     expect_raises(ArgumentError, /must start with/) do
-      app.use("items", Alumna::MemoryAdapter.new("items"))
+      app.use("items", Alumna::MemoryAdapter.new)
     end
   end
 end

--- a/spec/http/responder_spec.cr
+++ b/spec/http/responder_spec.cr
@@ -12,7 +12,7 @@ private def build_ctx(
   error : Alumna::ServiceError? = nil,
 ) : Alumna::RuleContext
   app = Alumna::App.new
-  service = Alumna::MemoryAdapter.new("/test")
+  service = Alumna::MemoryAdapter.new
   ctx = Alumna::RuleContext.new(
     app: app,
     service: service,

--- a/spec/http/router/remote_ip_spec.cr
+++ b/spec/http/router/remote_ip_spec.cr
@@ -5,7 +5,7 @@ require "http/server"
 # A tiny service that just echoes back the ip the router computed
 class IpEchoService < Alumna::MemoryAdapter
   def initialize
-    super("/ip", Alumna::Schema.new)
+    super(Alumna::Schema.new)
   end
 
   def find(ctx) : Array(Hash(String, Alumna::AnyData))

--- a/spec/http/router_spec.cr
+++ b/spec/http/router_spec.cr
@@ -39,7 +39,7 @@ class ItemService < Alumna::MemoryAdapter
           Alumna::ServiceError.unprocessable("Validation failed", details)
         end
       end,
-      only: [
+      on: [
         Alumna::ServiceMethod::Create,
         Alumna::ServiceMethod::Update,
       ]

--- a/spec/http/router_spec.cr
+++ b/spec/http/router_spec.cr
@@ -16,7 +16,7 @@ ItemSchema = Alumna::Schema.new
 # so we can also test that rule-generated errors propagate through the HTTP layer.
 class ItemService < Alumna::MemoryAdapter
   def initialize
-    super("/items", ItemSchema)
+    super(ItemSchema)
 
     self.before(Alumna::Rule.new do |ctx|
       token = ctx.headers["authorization"]?

--- a/spec/http/router_spec.cr
+++ b/spec/http/router_spec.cr
@@ -21,9 +21,9 @@ class ItemService < Alumna::MemoryAdapter
     self.before(Alumna::Rule.new do |ctx|
       token = ctx.headers["authorization"]?
       if token == "valid-token"
-        Alumna::RuleResult.continue
+        nil
       else
-        Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized("Invalid or missing token"))
+        Alumna::ServiceError.unauthorized("Invalid or missing token")
       end
     end)
 
@@ -31,12 +31,12 @@ class ItemService < Alumna::MemoryAdapter
       Alumna::Rule.new do |ctx|
         errors = ItemSchema.validate(ctx.data)
         if errors.empty?
-          Alumna::RuleResult.continue
+          nil
         else
           details = errors.each_with_object({} of String => Alumna::AnyData) do |e, h|
             h[e.field] = e.message
           end
-          Alumna::RuleResult.stop(Alumna::ServiceError.unprocessable("Validation failed", details))
+          Alumna::ServiceError.unprocessable("Validation failed", details)
         end
       end,
       only: [

--- a/spec/integration/app_spec.cr
+++ b/spec/integration/app_spec.cr
@@ -27,7 +27,7 @@ class TestService < Alumna::MemoryAdapter
   def initialize
     super(TestSchema)
     before Authenticate
-    before Alumna.validate(TestSchema), only: [:create, :update, :patch]
+    before Alumna.validate(TestSchema), on: :write
     after AfterLogger
   end
 end
@@ -36,7 +36,7 @@ class AfterFailService < Alumna::MemoryAdapter
   def initialize
     super(TestSchema)
     before Authenticate
-    before Alumna.validate(TestSchema), only: [:create, :update, :patch]
+    before Alumna.validate(TestSchema), on: :write
     after AfterLogger
     # this after-rule forces the failure path in App#dispatch
     after Alumna::Rule.new { |ctx|
@@ -55,7 +55,7 @@ class CorsService < Alumna::MemoryAdapter
     super()
     # OPTIONS is opt-in, so list all methods explicitly
     before Alumna.cors(origins: ["https://example.com"]),
-      only: [:find, :get, :create, :update, :patch, :remove, :options]
+      on: [:find, :get, :create, :update, :patch, :remove, :options]
   end
 end
 

--- a/spec/integration/app_spec.cr
+++ b/spec/integration/app_spec.cr
@@ -39,7 +39,7 @@ class AfterFailService < Alumna::MemoryAdapter
     before Alumna.validate(TestSchema), on: :write
     after AfterLogger
     # this after-rule forces the failure path in App#dispatch
-    after Alumna::Rule.new { |ctx|
+    after Alumna::Rule.new { |_ctx|
       Alumna::ServiceError.internal("after failed")
     }
     # service-level error hook

--- a/spec/integration/app_spec.cr
+++ b/spec/integration/app_spec.cr
@@ -25,7 +25,7 @@ end
 
 class TestService < Alumna::MemoryAdapter
   def initialize
-    super("/test", TestSchema)
+    super(TestSchema)
     before Authenticate
     before Alumna.validate(TestSchema), only: [:create, :update, :patch]
     after AfterLogger
@@ -34,7 +34,7 @@ end
 
 class AfterFailService < Alumna::MemoryAdapter
   def initialize
-    super("/after-stop", TestSchema)
+    super(TestSchema)
     before Authenticate
     before Alumna.validate(TestSchema), only: [:create, :update, :patch]
     after AfterLogger
@@ -52,7 +52,7 @@ end
 
 class CorsService < Alumna::MemoryAdapter
   def initialize
-    super("/cors-test")
+    super()
     # OPTIONS is opt-in, so list all methods explicitly
     before Alumna.cors(origins: ["https://example.com"]),
       only: [:find, :get, :create, :update, :patch, :remove, :options]

--- a/spec/integration/app_spec.cr
+++ b/spec/integration/app_spec.cr
@@ -10,17 +10,17 @@ TestSchema = Alumna::Schema.new
 
 Authenticate = Alumna::Rule.new do |ctx|
   token = ctx.headers["authorization"]?
-  token == "Bearer test-token" ? Alumna::RuleResult.continue : Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized)
+  token == "Bearer test-token" ? nil : Alumna::ServiceError.unauthorized
 end
 
 AfterLogger = Alumna::Rule.new do |ctx|
   ctx.http.headers["X-Request-ID"] = Random::Secure.hex(8)
-  Alumna::RuleResult.continue
+  nil
 end
 
 ErrorLogger = Alumna::Rule.new do |ctx|
   ctx.http.headers["X-Error-ID"] = "err-123"
-  Alumna::RuleResult.continue
+  nil
 end
 
 class TestService < Alumna::MemoryAdapter
@@ -40,12 +40,12 @@ class AfterFailService < Alumna::MemoryAdapter
     after AfterLogger
     # this after-rule forces the failure path in App#dispatch
     after Alumna::Rule.new { |ctx|
-      Alumna::RuleResult.stop(Alumna::ServiceError.internal("after failed"))
+      Alumna::ServiceError.internal("after failed")
     }
     # service-level error hook
     error Alumna::Rule.new { |ctx|
       ctx.http.headers["X-Service-Error"] = "svc-456"
-      Alumna::RuleResult.continue
+      nil
     }
   end
 end

--- a/spec/rule/base_spec.cr
+++ b/spec/rule/base_spec.cr
@@ -3,6 +3,7 @@ require "../spec_helper"
 private def dummy_ctx : Alumna::RuleContext
   app = Alumna::App.new
   service = Alumna::MemoryAdapter.new
+  app.use("/dummy", service)
   Alumna::RuleContext.new(
     app: app,
     service: service,
@@ -14,72 +15,31 @@ private def dummy_ctx : Alumna::RuleContext
   )
 end
 
-# proves the alias is structural, not tied to a specific literal
-def my_rule(ctx : Alumna::RuleContext) : Alumna::RuleResult
-  Alumna::RuleResult.continue
-end
-
-describe Alumna::RuleResult do
-  describe ".continue" do
-    it "creates a Continue result with no error" do
-      result = Alumna::RuleResult.continue
-
-      result.outcome.should eq(Alumna::RuleResult::Outcome::Continue)
-      result.error.should be_nil
-      result.continue?.should be_true
-      result.stop?.should be_false
-    end
-  end
-
-  describe ".stop" do
-    it "creates a Stop result with the given error" do
-      err = Alumna::ServiceError.unauthorized("nope")
-      result = Alumna::RuleResult.stop(err)
-
-      result.outcome.should eq(Alumna::RuleResult::Outcome::Stop)
-      result.error.should be(err)
-      result.error.should_not be_nil
-      result.error.as(Alumna::ServiceError).status.should eq(401)
-      result.continue?.should be_false
-      result.stop?.should be_true
-    end
-  end
-
-  describe "Outcome enum" do
-    it "exposes Continue and Stop" do
-      Alumna::RuleResult::Outcome::Continue.should eq(Alumna::RuleResult::Outcome::Continue)
-      Alumna::RuleResult::Outcome::Stop.continue?.should be_false
-      Alumna::RuleResult::Outcome::Continue.stop?.should be_false
-    end
-  end
+def my_rule(ctx : Alumna::RuleContext) : Alumna::ServiceError?
+  nil
 end
 
 describe "Alumna::Rule alias" do
-  it "accepts a Proc that takes RuleContext and returns RuleResult" do
-    rule : Alumna::Rule = ->(ctx : Alumna::RuleContext) {
+  it "accepts a Proc that returns nil to continue" do
+    rule = ->(ctx : Alumna::RuleContext) : Alumna::ServiceError? do
       ctx.headers["x"] = "1"
-      Alumna::RuleResult.continue
-    }
-
+      nil
+    end
     ctx = dummy_ctx
-    result = rule.call(ctx)
-
-    result.should be_a(Alumna::RuleResult)
-    result.continue?.should be_true
+    err = rule.call(ctx)
+    err.should be_nil
     ctx.headers["x"].should eq("1")
   end
 
-  it "works with Rule.new shorthand" do
-    rule = Alumna::Rule.new { |ctx| Alumna::RuleResult.stop(Alumna::ServiceError.forbidden) }
-
-    result = rule.call(dummy_ctx)
-    result.stop?.should be_true
-    result.error.should_not be_nil
-    result.error.as(Alumna::ServiceError).status.should eq(403)
+  it "accepts a Proc that returns ServiceError to stop" do
+    rule = Alumna::Rule.new { |ctx| Alumna::ServiceError.forbidden }
+    err = rule.call(dummy_ctx)
+    err.should_not be_nil
+    err.as(Alumna::ServiceError).status.should eq(403)
   end
 
   it "works with a captured method" do
-    rule : Alumna::Rule = ->my_rule(Alumna::RuleContext)
-    rule.call(dummy_ctx).continue?.should be_true
+    rule = ->my_rule(Alumna::RuleContext) # my_rule already returns ServiceError?
+    rule.call(dummy_ctx).should be_nil
   end
 end

--- a/spec/rule/base_spec.cr
+++ b/spec/rule/base_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 private def dummy_ctx : Alumna::RuleContext
   app = Alumna::App.new
-  service = Alumna::MemoryAdapter.new("/dummy")
+  service = Alumna::MemoryAdapter.new
   Alumna::RuleContext.new(
     app: app,
     service: service,

--- a/spec/rule/builtin/cors_spec.cr
+++ b/spec/rule/builtin/cors_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 module Alumna
   class TestService < Service
     def initialize
-      super("/test")
+      super()
     end
 
     def find(ctx : RuleContext) : Array(Hash(String, AnyData))

--- a/spec/rule/builtin/logger_spec.cr
+++ b/spec/rule/builtin/logger_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 module Alumna
   class TestService < Service
     def initialize
-      super("/test")
+      super()
     end
 
     def find(ctx : RuleContext) : Array(Hash(String, AnyData))

--- a/spec/rule/builtin/rate_limiter_spec.cr
+++ b/spec/rule/builtin/rate_limiter_spec.cr
@@ -15,7 +15,7 @@ end
 module Alumna
   class TestService < Service
     def initialize
-      super("/test")
+      super()
     end
 
     def find(ctx : RuleContext) : Array(Hash(String, AnyData))

--- a/spec/rule/builtin/rate_limiter_spec.cr
+++ b/spec/rule/builtin/rate_limiter_spec.cr
@@ -67,29 +67,28 @@ module Alumna
       rule = Alumna.rate_limit(limit: 1, window_seconds: 60)
       ctx = build_ctx_rate_limiter(app, service, "3.3.3")
       rule.call(ctx)
-      result = rule.call(ctx)
-      result.stop?.should be_true
-      result.error.try(&.status).should eq(429)
+      result = rule.call(ctx).should_not be_nil
+      result.status.should eq(429)
       ctx.http.headers["X-RateLimit-Remaining"].should eq("0")
     end
 
     it "resets count after window expires" do
       rule = Alumna.rate_limit(limit: 1, window_seconds: 0)
-      ctx = build_ctx_rate_limiter(app, service, "5.5.5.5")
+      ctx = build_ctx_rate_limiter(app, service, "5.5.5")
       first = rule.call(ctx)
-      first.continue?.should be_true
+      first.should be_nil
       ctx.http.headers["X-RateLimit-Remaining"].should eq("0")
       sleep 1.milliseconds
       second = rule.call(ctx)
-      second.continue?.should be_true
+      second.should be_nil
       ctx.http.headers["X-RateLimit-Remaining"].should eq("0")
     end
 
     it "skips OPTIONS" do
       rule = Alumna.rate_limit(limit: 1, window_seconds: 60)
-      ctx = build_ctx_rate_limiter(app, service, "4.4.4.4", "OPTIONS")
+      ctx = build_ctx_rate_limiter(app, service, "4.4.4", "OPTIONS")
       result = rule.call(ctx)
-      result.continue?.should be_true
+      result.should be_nil
       ctx.http.headers.has_key?("X-RateLimit-Limit").should be_false
     end
 
@@ -100,11 +99,11 @@ module Alumna
       ctx_a = build_ctx_rate_limiter(app, service, "10.0.0.1")
       ctx_b = build_ctx_rate_limiter(app, service, "10.0.0.2")
 
-      rule.call(ctx_a).continue?.should be_true
-      rule.call(ctx_b).continue?.should be_true
+      rule.call(ctx_a).should be_nil
+      rule.call(ctx_b).should be_nil
       # second hit for A should block, B still has its own bucket
-      rule.call(ctx_a).stop?.should be_true
-      rule.call(ctx_b).stop?.should be_true
+      rule.call(ctx_a).should_not be_nil
+      rule.call(ctx_b).should_not be_nil
     end
 
     it "prunes expired entries to prevent unbounded growth" do

--- a/spec/rule/orchestrator_spec.cr
+++ b/spec/rule/orchestrator_spec.cr
@@ -2,25 +2,19 @@ require "../spec_helper"
 
 # ── Helpers ───────────────────────────────────
 
-private def continuing_rule(log : Array(String), label : String) : Alumna::Rule
-  Alumna::Rule.new do |ctx|
-    log << label
-    Alumna::RuleResult.continue
-  end
+private def continuing_rule(log, label)
+  Alumna::Rule.new { |_ctx| log << label; nil }
 end
 
-private def stopping_rule(log : Array(String), label : String, message : String = "stopped") : Alumna::Rule
-  Alumna::Rule.new do |ctx|
-    log << label
-    Alumna::RuleResult.stop(Alumna::ServiceError.bad_request(message))
-  end
+private def stopping_rule(log, label, message = "stopped")
+  Alumna::Rule.new { |_ctx| log << label; Alumna::ServiceError.bad_request(message) }
 end
 
 private def result_setting_rule(log : Array(String), label : String) : Alumna::Rule
   Alumna::Rule.new do |ctx|
     log << label
     ctx.result = {"cached" => true} of String => Alumna::AnyData
-    Alumna::RuleResult.continue
+    nil.as(Alumna::ServiceError?)
   end
 end
 
@@ -66,7 +60,7 @@ describe Alumna::Orchestrator do
 
   describe "when a rule returns stop" do
     it "sets ctx.error to the ServiceError" do
-      rule = Alumna::Rule.new { |ctx| Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized("no token")) }
+      rule = Alumna::Rule.new { |ctx| Alumna::ServiceError.unauthorized("no token") }
       ctx = test_ctx
       Alumna::Orchestrator.run([rule], ctx)
       error = ctx.error
@@ -78,7 +72,7 @@ describe Alumna::Orchestrator do
     end
 
     it "returns false and does not change ctx.phase" do
-      rule = Alumna::Rule.new { |ctx| Alumna::RuleResult.stop(Alumna::ServiceError.forbidden) }
+      rule = Alumna::Rule.new { |ctx| Alumna::ServiceError.forbidden }
       ctx = test_ctx(phase: Alumna::RulePhase::Before)
       result = Alumna::Orchestrator.run([rule], ctx)
       result.should be_false
@@ -156,11 +150,11 @@ describe Alumna::Orchestrator do
     it "skips service error hooks when app before-rule stops" do
       log = [] of String
       app = Alumna::App.new
-      app.before(Alumna::Rule.new { |ctx| log << "app-before"; Alumna::RuleResult.stop(Alumna::ServiceError.forbidden) })
-      app.error(Alumna::Rule.new { |ctx| log << "app-error"; Alumna::RuleResult.continue })
+      app.before(Alumna::Rule.new { |ctx| log << "app-before"; Alumna::ServiceError.forbidden })
+      app.error(Alumna::Rule.new { |ctx| log << "app-error"; nil })
 
       svc = Alumna::MemoryAdapter.new
-      svc.error(Alumna::Rule.new { |ctx| log << "svc-error"; Alumna::RuleResult.continue })
+      svc.error(Alumna::Rule.new { |ctx| log << "svc-error"; nil })
       app.use("/x", svc)
 
       ctx = test_ctx(app: app, service: svc, method: Alumna::ServiceMethod::Find)

--- a/spec/rule/orchestrator_spec.cr
+++ b/spec/rule/orchestrator_spec.cr
@@ -159,7 +159,7 @@ describe Alumna::Orchestrator do
       app.before(Alumna::Rule.new { |ctx| log << "app-before"; Alumna::RuleResult.stop(Alumna::ServiceError.forbidden) })
       app.error(Alumna::Rule.new { |ctx| log << "app-error"; Alumna::RuleResult.continue })
 
-      svc = Alumna::MemoryAdapter.new("/x")
+      svc = Alumna::MemoryAdapter.new
       svc.error(Alumna::Rule.new { |ctx| log << "svc-error"; Alumna::RuleResult.continue })
       app.use("/x", svc)
 

--- a/spec/rule/orchestrator_spec.cr
+++ b/spec/rule/orchestrator_spec.cr
@@ -60,7 +60,7 @@ describe Alumna::Orchestrator do
 
   describe "when a rule returns stop" do
     it "sets ctx.error to the ServiceError" do
-      rule = Alumna::Rule.new { |ctx| Alumna::ServiceError.unauthorized("no token") }
+      rule = Alumna::Rule.new { |_ctx| Alumna::ServiceError.unauthorized("no token") }
       ctx = test_ctx
       Alumna::Orchestrator.run([rule], ctx)
       error = ctx.error
@@ -72,7 +72,7 @@ describe Alumna::Orchestrator do
     end
 
     it "returns false and does not change ctx.phase" do
-      rule = Alumna::Rule.new { |ctx| Alumna::ServiceError.forbidden }
+      rule = Alumna::Rule.new { |_ctx| Alumna::ServiceError.forbidden }
       ctx = test_ctx(phase: Alumna::RulePhase::Before)
       result = Alumna::Orchestrator.run([rule], ctx)
       result.should be_false
@@ -150,11 +150,11 @@ describe Alumna::Orchestrator do
     it "skips service error hooks when app before-rule stops" do
       log = [] of String
       app = Alumna::App.new
-      app.before(Alumna::Rule.new { |ctx| log << "app-before"; Alumna::ServiceError.forbidden })
-      app.error(Alumna::Rule.new { |ctx| log << "app-error"; nil })
+      app.before(Alumna::Rule.new { |_ctx| log << "app-before"; Alumna::ServiceError.forbidden })
+      app.error(Alumna::Rule.new { |_ctx| log << "app-error"; nil })
 
       svc = Alumna::MemoryAdapter.new
-      svc.error(Alumna::Rule.new { |ctx| log << "svc-error"; nil })
+      svc.error(Alumna::Rule.new { |_ctx| log << "svc-error"; nil })
       app.use("/x", svc)
 
       ctx = test_ctx(app: app, service: svc, method: Alumna::ServiceMethod::Find)

--- a/spec/rule/ruleable_spec.cr
+++ b/spec/rule/ruleable_spec.cr
@@ -19,7 +19,7 @@ describe Alumna::Ruleable do
   end
 
   it "registers specific after rules with symbols" do
-    r = DummyRuleable.new.after(rule, only: [:create, :update])
+    r = DummyRuleable.new.after(rule, on: [:create, :update])
     creates = r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::After)
     finds = r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::After)
     creates.size.should eq(1)
@@ -27,31 +27,31 @@ describe Alumna::Ruleable do
   end
 
   it "normalizes symbols to enums" do
-    r = DummyRuleable.new.before(rule, only: :patch)
+    r = DummyRuleable.new.before(rule, on: :patch)
     r.collect_rules(Alumna::ServiceMethod::Patch, Alumna::RulePhase::Before).size.should eq(1)
   end
 
   it "accepts single enum overload for before" do
     r = DummyRuleable.new
-    r.before(rule, only: Alumna::ServiceMethod::Find)
+    r.before(rule, on: Alumna::ServiceMethod::Find)
     r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
   end
 
   it "accepts single symbol and normalizes via capitalize" do
     r = DummyRuleable.new
-    r.before(rule, only: :create)
+    r.before(rule, on: :create)
     r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Before).size.should eq(1)
   end
 
   it "accepts uppercase symbol for after" do
     r = DummyRuleable.new
-    r.after(rule, only: :FIND)
+    r.after(rule, on: :FIND)
     r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::After).size.should eq(1)
   end
 
   it "accepts array of symbols" do
     r = DummyRuleable.new
-    r.before(rule, only: [:find, :create])
+    r.before(rule, on: [:find, :create])
     r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
     r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Before).size.should eq(1)
     r.collect_rules(Alumna::ServiceMethod::Get, Alumna::RulePhase::Before).size.should eq(0)
@@ -64,7 +64,7 @@ describe Alumna::Ruleable do
     specific = Alumna::Rule.new { |ctx| order << "specific"; nil.as(Alumna::ServiceError?) }
 
     r.before(global)
-    r.before(specific, only: :get)
+    r.before(specific, on: :get)
 
     rules = r.collect_rules(Alumna::ServiceMethod::Get, Alumna::RulePhase::Before)
     Alumna::Orchestrator.run(rules, test_ctx(method: Alumna::ServiceMethod::Get))
@@ -87,7 +87,7 @@ describe Alumna::Ruleable do
     app = Alumna::App.new
     svc = Alumna::MemoryAdapter.new
     app.before(rule)
-    svc.before(rule, only: :find)
+    svc.before(rule, on: :find)
 
     app.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
     svc.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
@@ -100,13 +100,13 @@ describe Alumna::Ruleable do
 
   it "accepts single enum overload for error" do
     r = DummyRuleable.new
-    r.error(rule, only: Alumna::ServiceMethod::Find)
+    r.error(rule, on: Alumna::ServiceMethod::Find)
     r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Error).size.should eq(1)
   end
 
   it "accepts single symbol for error and normalizes" do
     r = DummyRuleable.new
-    r.error(rule, only: :create)
+    r.error(rule, on: :create)
     r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Error).size.should eq(1)
   end
 end

--- a/spec/rule/ruleable_spec.cr
+++ b/spec/rule/ruleable_spec.cr
@@ -5,7 +5,7 @@ class DummyRuleable
 end
 
 describe Alumna::Ruleable do
-  rule = ->(ctx : Alumna::RuleContext) : Alumna::ServiceError? { nil }
+  rule = ->(_ctx : Alumna::RuleContext) : Alumna::ServiceError? { nil }
 
   it "registers global before rules" do
     r = DummyRuleable.new.before(rule)
@@ -60,8 +60,8 @@ describe Alumna::Ruleable do
   it "runs global before specific" do
     r = DummyRuleable.new
     order = [] of String
-    global = Alumna::Rule.new { |ctx| order << "global"; nil.as(Alumna::ServiceError?) }
-    specific = Alumna::Rule.new { |ctx| order << "specific"; nil.as(Alumna::ServiceError?) }
+    global = Alumna::Rule.new { |_ctx| order << "global"; nil.as(Alumna::ServiceError?) }
+    specific = Alumna::Rule.new { |_ctx| order << "specific"; nil.as(Alumna::ServiceError?) }
 
     r.before(global)
     r.before(specific, on: :get)
@@ -108,5 +108,25 @@ describe Alumna::Ruleable do
     r = DummyRuleable.new
     r.error(rule, on: :create)
     r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Error).size.should eq(1)
+  end
+
+  it "registers before rules via block form" do
+    r = DummyRuleable.new.before { |_ctx| nil }
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Options, Alumna::RulePhase::Before).size.should eq(0)
+  end
+
+  it "registers after rules via block form with on: :write" do
+    r = DummyRuleable.new.after(on: :write) { |_ctx| nil }
+    r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::After).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Update, Alumna::RulePhase::After).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::After).size.should eq(0)
+  end
+
+  it "registers error rules via block form with on: :read" do
+    r = DummyRuleable.new.error(on: :read) { |_ctx| nil }
+    r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Error).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Get, Alumna::RulePhase::Error).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Error).size.should eq(0)
   end
 end

--- a/spec/rule/ruleable_spec.cr
+++ b/spec/rule/ruleable_spec.cr
@@ -5,7 +5,7 @@ class DummyRuleable
 end
 
 describe Alumna::Ruleable do
-  rule = ->(ctx : Alumna::RuleContext) { Alumna::RuleResult.continue }
+  rule = ->(ctx : Alumna::RuleContext) : Alumna::ServiceError? { nil }
 
   it "registers global before rules" do
     r = DummyRuleable.new.before(rule)
@@ -60,8 +60,8 @@ describe Alumna::Ruleable do
   it "runs global before specific" do
     r = DummyRuleable.new
     order = [] of String
-    global = Alumna::Rule.new { order << "global"; Alumna::RuleResult.continue }
-    specific = Alumna::Rule.new { order << "specific"; Alumna::RuleResult.continue }
+    global = Alumna::Rule.new { |ctx| order << "global"; nil.as(Alumna::ServiceError?) }
+    specific = Alumna::Rule.new { |ctx| order << "specific"; nil.as(Alumna::ServiceError?) }
 
     r.before(global)
     r.before(specific, only: :get)

--- a/spec/rule/ruleable_spec.cr
+++ b/spec/rule/ruleable_spec.cr
@@ -85,7 +85,7 @@ describe Alumna::Ruleable do
 
   it "works identically in App and Service" do
     app = Alumna::App.new
-    svc = Alumna::MemoryAdapter.new("/test")
+    svc = Alumna::MemoryAdapter.new
     app.before(rule)
     svc.before(rule, only: :find)
 

--- a/spec/service/base_spec.cr
+++ b/spec/service/base_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 private class ExplodingService < Alumna::Service
   def initialize
-    super("/boom")
+    super()
   end
 
   def find(ctx) : Array(Hash(String, Alumna::AnyData))
@@ -32,9 +32,9 @@ end
 
 private def dispatch(svc, method)
   app = Alumna::App.new
-  app.use(svc.path, svc)
+  app.use("/boom", svc)
   ctx = Alumna::RuleContext.new(
-    app: app, service: svc, path: svc.path, method: method,
+    app: app, service: svc, path: "/boom", method: method,
     phase: Alumna::RulePhase::Before,
     params: Alumna::Http::ParamsView.new(HTTP::Params.new),
     headers: Alumna::Http::HeadersView.new(HTTP::Headers.new)

--- a/spec/service/dispatch_spec.cr
+++ b/spec/service/dispatch_spec.cr
@@ -132,11 +132,11 @@ describe "Dispatch" do
     end
   end
 
-  describe "only: scoping" do
+  describe "on: scoping" do
     it "runs a method-scoped rule only for its registered method" do
       log = [] of String
       service = TrackedService.new
-      service.before(continuing_rule(log, "create-only"), only: [Alumna::ServiceMethod::Create])
+      service.before(continuing_rule(log, "create-only"), on: [Alumna::ServiceMethod::Create])
 
       dispatch(service, Alumna::ServiceMethod::Find)
       log.should be_empty
@@ -148,7 +148,7 @@ describe "Dispatch" do
     it "does not run a method-scoped rule for any other method" do
       log = [] of String
       service = TrackedService.new
-      service.after(continuing_rule(log, "find-after"), only: [Alumna::ServiceMethod::Find])
+      service.after(continuing_rule(log, "find-after"), on: [Alumna::ServiceMethod::Find])
 
       dispatch(service, Alumna::ServiceMethod::Create, nil, {"x" => "y"} of String => Alumna::AnyData)
       log.should be_empty

--- a/spec/service/dispatch_spec.cr
+++ b/spec/service/dispatch_spec.cr
@@ -53,23 +53,18 @@ private def dispatch(service, method, id = nil, data = {} of String => Alumna::A
   ctx
 end
 
-private def continuing_rule(log : Array(String), label : String) : Alumna::Rule
-  Alumna::Rule.new do |ctx|
-    log << label
-    Alumna::RuleResult.continue
-  end
+private def continuing_rule(log, label)
+  Alumna::Rule.new { |_ctx| log << label; nil }
 end
 
-private def stopping_rule(label : String) : Alumna::Rule
-  Alumna::Rule.new do |ctx|
-    Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized(label))
-  end
+private def stopping_rule(message : String) : Alumna::Rule
+  Alumna::Rule.new { |_ctx| Alumna::ServiceError.unauthorized(message) }
 end
 
 private def result_setting_rule(label : String) : Alumna::Rule
   Alumna::Rule.new do |ctx|
     ctx.result = {"shortcut" => label} of String => Alumna::AnyData
-    Alumna::RuleResult.continue
+    nil.as(Alumna::ServiceError?)
   end
 end
 
@@ -93,7 +88,7 @@ describe "Dispatch" do
       service = TrackedService.new
       service.after(Alumna::Rule.new do |ctx|
         observed_phase = ctx.phase
-        Alumna::RuleResult.continue
+        nil
       end)
 
       dispatch(service, Alumna::ServiceMethod::Find)
@@ -105,7 +100,7 @@ describe "Dispatch" do
       service = TrackedService.new
       service.after(Alumna::Rule.new do |ctx|
         observed_result = ctx.result
-        Alumna::RuleResult.continue
+        nil
       end)
 
       dispatch(service, Alumna::ServiceMethod::Find)
@@ -116,7 +111,7 @@ describe "Dispatch" do
       log = [] of String
       svc = TrackedService.new
       svc.before(stopping_rule("boom"))
-      svc.error(Alumna::Rule.new { log << "error"; Alumna::RuleResult.continue })
+      svc.error(Alumna::Rule.new { log << "error"; nil })
 
       ctx = dispatch(svc, Alumna::ServiceMethod::Find)
       log.should eq(["error"])
@@ -127,7 +122,7 @@ describe "Dispatch" do
       log = [] of String
       app = Alumna::App.new
       svc = TrackedService.new
-      app.error(Alumna::Rule.new { log << "app-error"; Alumna::RuleResult.continue })
+      app.error(Alumna::Rule.new { log << "app-error"; nil })
       app.use("/x", svc)
 
       ctx = make_ctx(app, svc, Alumna::ServiceMethod::Update, "999")
@@ -165,10 +160,10 @@ describe "Dispatch" do
       log = [] of String
       app = Alumna::App.new
       svc = TrackedService.new
-      app.before(Alumna::Rule.new { log << "app-before"; Alumna::RuleResult.continue })
-      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
-      svc.before(Alumna::Rule.new { log << "svc-before"; Alumna::RuleResult.continue })
-      svc.after(Alumna::Rule.new { log << "svc-after"; Alumna::RuleResult.continue })
+      app.before(Alumna::Rule.new { log << "app-before"; nil })
+      app.after(Alumna::Rule.new { log << "app-after"; nil })
+      svc.before(Alumna::Rule.new { log << "svc-before"; nil })
+      svc.after(Alumna::Rule.new { log << "svc-after"; nil })
       app.use("/ordered", svc)
 
       ctx = make_ctx(app, svc, Alumna::ServiceMethod::Find)
@@ -181,9 +176,9 @@ describe "Dispatch" do
       log = [] of String
       app = Alumna::App.new
       svc = TrackedService.new
-      app.before(Alumna::Rule.new { log << "app-before"; Alumna::RuleResult.stop(Alumna::ServiceError.unauthorized) })
-      svc.before(Alumna::Rule.new { log << "svc-before"; Alumna::RuleResult.continue })
-      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
+      app.before(Alumna::Rule.new { log << "app-before"; Alumna::ServiceError.unauthorized })
+      svc.before(Alumna::Rule.new { log << "svc-before"; nil })
+      app.after(Alumna::Rule.new { log << "app-after"; nil })
       app.use("/x", svc)
 
       ctx = make_ctx(app, svc, Alumna::ServiceMethod::Find)
@@ -200,9 +195,9 @@ describe "Dispatch" do
       app.before(Alumna::Rule.new { |c|
         c.result = {"cached" => true} of String => Alumna::AnyData
         log << "app-before"
-        Alumna::RuleResult.continue
+        nil
       })
-      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
+      app.after(Alumna::Rule.new { log << "app-after"; nil })
       app.use("/x", svc)
 
       ctx = make_ctx(app, svc, Alumna::ServiceMethod::Find)
@@ -217,7 +212,7 @@ describe "Dispatch" do
       app = Alumna::App.new
       svc = TrackedService.new
       svc.before(stopping_rule("boom"))
-      app.after(Alumna::Rule.new { log << "app-after"; Alumna::RuleResult.continue })
+      app.after(Alumna::Rule.new { log << "app-after"; nil })
       app.use("/x", svc)
 
       ctx = make_ctx(app, svc, Alumna::ServiceMethod::Find)

--- a/spec/service/dispatch_spec.cr
+++ b/spec/service/dispatch_spec.cr
@@ -4,7 +4,7 @@ private class TrackedService < Alumna::MemoryAdapter
   getter called : Array(String)
 
   def initialize
-    super("/tracked")
+    super()
     @called = [] of String
   end
 
@@ -46,7 +46,8 @@ end
 
 private def dispatch(service, method, id = nil, data = {} of String => Alumna::AnyData, app = nil)
   app ||= Alumna::App.new
-  app.use(service.path, service) unless app.services.has_key?(service.path)
+  mount_path = "/tracked" # TrackedService is always mounted here in this spec
+  app.use(mount_path, service) unless app.services.has_key?(mount_path)
   ctx = make_ctx(app, service, method, id, data)
   app.dispatch(service, ctx)
   ctx

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,7 +3,7 @@ require "../src/alumna"
 
 def test_ctx(
   app = Alumna::App.new,
-  service = Alumna::MemoryAdapter.new("/test"),
+  service = Alumna::MemoryAdapter.new,
   path = "/test",
   method = Alumna::ServiceMethod::Find,
   phase = Alumna::RulePhase::Before,

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -4,8 +4,8 @@ module Alumna
     @next_id : Int64
     @mutex : Mutex
 
-    def initialize(path : String, schema : Schema? = nil)
-      super(path, schema)
+    def initialize(schema : Schema? = nil)
+      super(schema)
       @store = {} of String => Hash(String, AnyData)
       @next_id = 1_i64
       @mutex = Mutex.new

--- a/src/app.cr
+++ b/src/app.cr
@@ -19,6 +19,7 @@ module Alumna
     def use(path : String, service : Service) : self
       normalized = normalize_path(path)
       raise ArgumentError.new("service already mounted at #{normalized}") if @services.has_key?(normalized)
+      service.path = normalized
       @services[normalized] = service
       self
     end

--- a/src/rule/base.cr
+++ b/src/rule/base.cr
@@ -1,34 +1,6 @@
 module Alumna
-  # A Rule is simply a Proc that receives a context and returns a RuleResult.
-  # This alias means any method, lambda, or proc with the right signature qualifies.
-  alias Rule = Proc(RuleContext, RuleResult)
-
-  struct RuleResult
-    getter outcome : Outcome
-    getter error : ServiceError?
-
-    enum Outcome
-      Continue
-      Stop
-    end
-
-    def self.continue : RuleResult
-      new(Outcome::Continue, nil)
-    end
-
-    def self.stop(error : ServiceError) : RuleResult
-      new(Outcome::Stop, error)
-    end
-
-    def continue? : Bool
-      @outcome.continue?
-    end
-
-    def stop? : Bool
-      @outcome.stop?
-    end
-
-    private def initialize(@outcome : Outcome, @error : ServiceError?)
-    end
-  end
+  # A Rule receives the context and returns:
+  # - nil          → continue to next rule
+  # - ServiceError → stop the pipeline and store the error in ctx.error
+  alias Rule = Proc(RuleContext, ServiceError?)
 end

--- a/src/rule/builtin/cors.cr
+++ b/src/rule/builtin/cors.cr
@@ -25,7 +25,7 @@ module Alumna
 
     Rule.new do |ctx|
       origin = ctx.headers["origin"]?
-      next RuleResult.continue unless origin
+      next nil unless origin
 
       # same normalization for the incoming value – O(1) string ops
       origin_norm = origin.strip.downcase.chomp('/')
@@ -36,7 +36,7 @@ module Alumna
                          origin # echo the client's exact value, spec-compliant
                        end
 
-      next RuleResult.continue unless allowed_origin
+      next nil unless allowed_origin
 
       h = ctx.http.headers
       h["Access-Control-Allow-Origin"] = allowed_origin
@@ -52,7 +52,7 @@ module Alumna
         ctx.result = {} of String => AnyData
       end
 
-      RuleResult.continue
+      nil
     end
   end
 end

--- a/src/rule/builtin/logger.cr
+++ b/src/rule/builtin/logger.cr
@@ -17,7 +17,7 @@ module Alumna
 
         io.puts %(#{ctx.remote_ip} "#{ctx.http_method} #{path}" #{status} #{ms}ms)
       end
-      RuleResult.continue
+      nil
     end
   end
 end

--- a/src/rule/builtin/rate_limiter.cr
+++ b/src/rule/builtin/rate_limiter.cr
@@ -95,7 +95,7 @@ module Alumna
     store = RateLimitStore.new(window_seconds.seconds)
 
     Rule.new do |ctx|
-      next RuleResult.continue if ctx.http_method == "OPTIONS"
+      next nil if ctx.http_method == "OPTIONS"
 
       count, reset_at = store.hit(key.call(ctx))
 
@@ -106,9 +106,9 @@ module Alumna
       ctx.http.headers["X-RateLimit-Reset"] = reset_at.to_unix.to_s
 
       if count > limit
-        RuleResult.stop(ServiceError.new("Too Many Requests", 429))
+        ServiceError.new("Too Many Requests", 429)
       else
-        RuleResult.continue
+        nil
       end
     end
   end

--- a/src/rule/builtin/validate.cr
+++ b/src/rule/builtin/validate.cr
@@ -2,9 +2,9 @@ module Alumna
   def self.validate(schema : Schema) : Rule
     Rule.new do |ctx|
       errors = schema.validate(ctx.data, ctx.method)
-      next RuleResult.continue if errors.empty?
+      next nil if errors.empty?
       details = errors.each_with_object({} of String => AnyData) { |e, h| h[e.field] = e.message }
-      RuleResult.stop(ServiceError.unprocessable("Validation failed", details))
+      ServiceError.unprocessable("Validation failed", details)
     end
   end
 end

--- a/src/rule/orchestrator.cr
+++ b/src/rule/orchestrator.cr
@@ -4,9 +4,8 @@ module Alumna
       i = 0
       size = rules.size
       while i < size
-        result = rules.unsafe_fetch(i).call(ctx)
-        if result.stop?
-          ctx.error = result.error
+        if err = rules.unsafe_fetch(i).call(ctx)
+          ctx.error = err
           return false
         end
         return true if short_circuit && ctx.result_set?
@@ -19,9 +18,8 @@ module Alumna
       i = 0
       size = rules.size
       while i < size
-        result = rules.unsafe_fetch(i).call(ctx)
-        if result.stop?
-          ctx.error = result.error
+        if err = rules.unsafe_fetch(i).call(ctx)
+          ctx.error = err
           return {false, i < boundary}
         end
         return {true, false} if short_circuit && ctx.result_set?

--- a/src/rule/ruleable.cr
+++ b/src/rule/ruleable.cr
@@ -12,8 +12,8 @@ module Alumna
       self
     end
 
-    def before(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, & : RuleContext -> _)
-      before(Rule.new { |ctx| yield(ctx).as(ServiceError?) }, on: on)
+    def before(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, &block : RuleContext -> ServiceError?)
+      before(block, on: on)
     end
 
     def after(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
@@ -21,8 +21,8 @@ module Alumna
       self
     end
 
-    def after(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, & : RuleContext -> _)
-      after(Rule.new { |ctx| yield(ctx).as(ServiceError?) }, on: on)
+    def after(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, &block : RuleContext -> ServiceError?)
+      after(block, on: on)
     end
 
     def error(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
@@ -30,8 +30,8 @@ module Alumna
       self
     end
 
-    def error(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, & : RuleContext -> _)
-      error(Rule.new { |ctx| yield(ctx).as(ServiceError?) }, on: on)
+    def error(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, &block : RuleContext -> ServiceError?)
+      error(block, on: on)
     end
 
     # ---- internals ----

--- a/src/rule/ruleable.cr
+++ b/src/rule/ruleable.cr
@@ -1,79 +1,74 @@
 module Alumna
   module Ruleable
-    alias RuleMap = Hash(ServiceMethod?, Hash(RulePhase, Array(Rule)))
+    # Eager, non-nilable storage - each App/Service gets its own hashes
+    @before_rules = Hash(ServiceMethod, Array(Rule)).new { |h, k| h[k] = [] of Rule }
+    @after_rules = Hash(ServiceMethod, Array(Rule)).new { |h, k| h[k] = [] of Rule }
+    @error_rules = Hash(ServiceMethod, Array(Rule)).new { |h, k| h[k] = [] of Rule }
 
-    @rules : RuleMap = RuleMap.new
+    # ---- public API ----
 
-    # Built lazily to avoid compile-time enum lookup issues
-    EMPTY_RULES = [] of Rule
-    @compiled : Array(Array(Array(Rule)))? = nil
-
-    # --- public API ---
-    def before(rule : Rule, only : ServiceMethod | Symbol) : self
-      before(rule, only: [only])
-    end
-
-    def after(rule : Rule, only : ServiceMethod | Symbol) : self
-      after(rule, only: [only])
-    end
-
-    def before(rule : Rule, only : Array(ServiceMethod | Symbol) = [] of ServiceMethod) : self
-      register_rule(RulePhase::Before, normalize_methods(only), rule)
+    def before(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
+      register_rule(:before, rule, on)
       self
     end
 
-    def after(rule : Rule, only : Array(ServiceMethod | Symbol) = [] of ServiceMethod) : self
-      register_rule(RulePhase::After, normalize_methods(only), rule)
+    def before(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, & : RuleContext -> _)
+      before(Rule.new { |ctx| yield(ctx).as(ServiceError?) }, on: on)
+    end
+
+    def after(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
+      register_rule(:after, rule, on)
       self
     end
 
-    def error(rule : Rule, only : ServiceMethod | Symbol) : self
-      error(rule, only: [only])
+    def after(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, & : RuleContext -> _)
+      after(Rule.new { |ctx| yield(ctx).as(ServiceError?) }, on: on)
     end
 
-    def error(rule : Rule, only : Array(ServiceMethod | Symbol) = [] of ServiceMethod) : self
-      register_rule(RulePhase::Error, normalize_methods(only), rule)
+    def error(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
+      register_rule(:error, rule, on)
       self
     end
 
-    # --- hot path ---
+    def error(on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil, & : RuleContext -> _)
+      error(Rule.new { |ctx| yield(ctx).as(ServiceError?) }, on: on)
+    end
+
+    # ---- internals ----
     def collect_rules(method : ServiceMethod, phase : RulePhase) : Array(Rule)
-      ensure_compiled![method.value][phase.value]
+      case phase
+      in RulePhase::Before then @before_rules[method]
+      in RulePhase::After  then @after_rules[method]
+      in RulePhase::Error  then @error_rules[method]
+      end
     end
 
-    private def register_rule(phase : RulePhase, methods : Array(ServiceMethod), rule : Rule)
-      targets = methods.empty? ? [nil] : methods.map(&.as(ServiceMethod?))
-      targets.each do |target|
-        @rules[target] ||= {} of RulePhase => Array(Rule)
-        @rules[target][phase] ||= [] of Rule
-        @rules[target][phase] << rule
+    private def register_rule(phase : Symbol, rule : Rule, on)
+      target = case phase
+               when :before then @before_rules
+               when :after  then @after_rules
+               when :error  then @error_rules
+               else
+                 raise "BUG: Ruleable.register_rule invalid phase #{phase.inspect}"
+               end
 
-        if target.nil?
-          ServiceMethod.values.each { |m| rebuild_index(m, phase) }
-        else
-          rebuild_index(target, phase)
+      expand_on(on).each { |m| target[m] << rule }
+    end
+
+    private def expand_on(on) : Array(ServiceMethod)
+      return ServiceMethod.values.reject(&.options?) if on.nil?
+
+      items = on.is_a?(Array) ? on : [on]
+      items.flat_map do |item|
+        case item
+        when ServiceMethod then [item]
+        when :read         then [ServiceMethod::Find, ServiceMethod::Get]
+        when :write        then [ServiceMethod::Create, ServiceMethod::Update, ServiceMethod::Patch, ServiceMethod::Remove]
+        when :all          then ServiceMethod.values.reject(&.options?)
+        when Symbol        then [ServiceMethod.parse(item.to_s)]
+        else                    [] of ServiceMethod
         end
-      end
-    end
-
-    private def rebuild_index(method : ServiceMethod, phase : RulePhase)
-      compiled = ensure_compiled!
-      global = @rules[nil]?.try(&.[phase]?) || EMPTY_RULES
-      specific = @rules[method]?.try(&.[phase]?) || EMPTY_RULES
-      # CONVENTION: OPTIONS is opt-in. Global rules (registered without `only:`)
-      # apply to data methods only, not to preflights.
-      compiled[method.value][phase.value] = method.options? ? specific : global + specific
-    end
-
-    # Returns the matrix, creating it once on first use
-    private def ensure_compiled! : Array(Array(Array(Rule)))
-      @compiled ||= Array.new(ServiceMethod.values.size) do
-        Array.new(RulePhase.values.size) { EMPTY_RULES }
-      end
-    end
-
-    private def normalize_methods(only) : Array(ServiceMethod)
-      only.map { |m| m.is_a?(Symbol) ? ServiceMethod.parse(m.to_s.capitalize) : m }
+      end.uniq!
     end
   end
 end

--- a/src/service/base.cr
+++ b/src/service/base.cr
@@ -2,7 +2,7 @@ module Alumna
   abstract class Service
     include Ruleable
 
-    getter path : String
+    property path : String = ""
     getter schema : Schema?
 
     # Merged pipelines built by App.use
@@ -10,7 +10,7 @@ module Alumna
     @after_pipeline : Array(Array(Rule))
     @before_app_len : Array(Int32)
 
-    def initialize(@path : String, @schema : Schema? = nil)
+    def initialize(@schema : Schema? = nil)
       size = ServiceMethod.values.size
       @before_pipeline = Array.new(size) { [] of Rule }
       @after_pipeline = Array.new(size) { [] of Rule }


### PR DESCRIPTION
**Simplifications:**

- refactor: remove `path` from Service
- refactor: remove `RuleResult.continue/stop` to simplify rules execution
- feat: allow blocks on `before`, `after` and `error` for short rules
- perf: registering rules with a block has no performance penalty