### PR TITLE
refactor: simplifications - part 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ All fields are required unless you pass `required: false` or limit them with `re
 | `.str("title")` | required on every method |
 | `.str("title", required: false)` | optional on every method |
 | `.str("title", required_on: [:create, :update])` | required only for create and update, optional for patch |
+| `.str("title", required_on: :create)` | required only for create, optional for the rest |
 
 ### Validation: Built-in validation rule
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ end
 app = Alumna::App.new
 
 # Messages service based on Memory adapter
-app.use "/messages", Alumna.memory(MessageSchema) do
+app.use "/messages", Alumna.memory(MessageSchema) {
   before Authenticate
-  before Alumna.validate(MessageSchema), on: :write
-end
+  before validate, on: :write
+}
+
 # Done
 app.listen(3000) # binds to 127.0.0.1:3000 by default
 ```
@@ -224,6 +225,19 @@ end
 
 You still keep full control - write your own rule when you need custom messages, transformations, or conditional validation. `Alumna.validate` is just a zero-magic shortcut for the 90% case.
 
+#### Leaner way to use validation
+
+When registering rules, you can use the direct internal helper, and the `UserService` above can be:
+
+```crystal
+class UserService < Alumna::MemoryAdapter
+  def initialize
+    super(UserSchema)
+    before validate, on: :write
+  end
+end
+```
+
 ### Validation: custom validator
 
 Schemas are plain objects. When needed, inside your own rule, call `schema.validate(data, method)` to get back an `Array(Alumna::FieldError)`. Pass the current `ctx.method` so `required_on` is respected:
@@ -247,6 +261,13 @@ Alumna.rate_limit(limit: 100, window_seconds: 60) # in-memory rate limiting
 ```crystal
 before Alumna.validate(UserSchema), on: :write
 ```
+
+or the reduced helper, which already infers which is the schema used in the service:
+
+```crystal
+before validate, on: :write
+```
+
 Returns 422 with per-field details when validation fails. Respects `required_on`.
 
 **2. CORS**
@@ -448,7 +469,7 @@ class UserService < Alumna::MemoryAdapter
   def initialize
     super(UserSchema)
     before Authenticate
-    before Alumna.validate(UserSchema), on: :write
+    before validate, on: :write
     after AddRequestId
     error LogError
   end
@@ -462,7 +483,7 @@ For simple services that only need to configure rules, you can skip the class de
 ```crystal
 app.use "/messages", Alumna.memory(MessageSchema) do
   before Authenticate
-  before Alumna.validate(MessageSchema), on: :write
+  before validate, on: :write
   after AddRequestId
 end
 ```
@@ -575,30 +596,22 @@ Authenticate = Alumna::Rule.new do |ctx|
   token == "Bearer my-secret" ? nil : Alumna::ServiceError.unauthorized
 end
 
-class UserService < Alumna::MemoryAdapter
-  def initialize
-    super(UserSchema)
-    before Authenticate
-    before Alumna.validate(UserSchema), on: :write
-  end
-end
-
-class PostService < Alumna::MemoryAdapter
-  def initialize
-    super(PostSchema)
-    before Authenticate
-    before Alumna.validate(PostSchema), on: :write
-
-  end
-end
-
 app = Alumna::App.new
-app.use("/users", UserService.new)
-app.use("/posts", PostService.new)
+
+app.use "/users", Alumna.memory(UserSchema) {
+  before Authenticate
+  before validate, on: :write
+}
+
+app.use "/posts", Alumna.memory(PostSchema) {
+  before Authenticate
+  before validate, on: :write
+}
+
 app.listen(3000) # http://127.0.0.1:3000
 ```
 
-PATCH works without sending required fields, because `required_on` limits the requirement to create/update.
+In this example, `PATCH` works without sending required fields, because `required_on` limits the requirement to create/update.
 
 ---
 

--- a/examples/messages.cr
+++ b/examples/messages.cr
@@ -15,15 +15,10 @@ LogResult = Alumna::Rule.new do |ctx|
   nil
 end
 
-class MessageService < Alumna::MemoryAdapter
-  def initialize
-    super(MessageSchema)
-    before Authenticate
-    before Alumna.validate(MessageSchema), on: :write
-    after LogResult
-  end
-end
-
 app = Alumna::App.new
-app.use("/messages", MessageService.new)
+app.use "/messages", Alumna.memory(MessageSchema) {
+  before Authenticate
+  before validate, on: :write
+  after LogResult
+}
 app.listen(3000)

--- a/examples/user-posts.cr
+++ b/examples/user-posts.cr
@@ -14,23 +14,16 @@ Authenticate = Alumna::Rule.new do |ctx|
   token == "Bearer my-secret" ? nil : Alumna::ServiceError.unauthorized
 end
 
-class UserService < Alumna::MemoryAdapter
-  def initialize
-    super(UserSchema)
-    before Authenticate
-    before Alumna.validate(UserSchema), on: :write
-  end
-end
-
-class PostService < Alumna::MemoryAdapter
-  def initialize
-    super(PostSchema)
-    before Authenticate
-    before Alumna.validate(PostSchema), on: :write
-  end
-end
-
 app = Alumna::App.new
-app.use("/users", UserService.new)
-app.use("/posts", PostService.new)
+
+app.use "/users", Alumna.memory(UserSchema) {
+  before Authenticate
+  before validate, on: :write
+}
+
+app.use "/posts", Alumna.memory(PostSchema) {
+  before Authenticate
+  before validate, on: :write
+}
+
 app.listen(3000)

--- a/examples/user-posts.cr
+++ b/examples/user-posts.cr
@@ -1,8 +1,8 @@
 require "../src/alumna"
 
 UserSchema = Alumna::Schema.new
-  .str("name", required: true, min_length: 2, max_length: 100)
-  .str("email", required: true, format: :email)
+  .str("name", min_length: 2, max_length: 100)
+  .str("email", format: :email)
   .int("age", required: false)
 
 PostSchema = Alumna::Schema.new

--- a/spec/integration/app_spec.cr
+++ b/spec/integration/app_spec.cr
@@ -79,12 +79,14 @@ describe "Alumna System Integration" do
     app.use("/test", TestService.new)
     app.use("/after-stop", AfterFailService.new)
     app.use("/cors-test", CorsService.new)
+
     # New: direct block style, no class needed
-    app.use("/block", Alumna.memory(TestSchema) do
+    app.use "/block", Alumna.memory(TestSchema) {
       before Authenticate
       before Alumna.validate(TestSchema), on: :write
       after AfterLogger
-    end)
+    }
+
     spawn { app.listen(TEST_PORT) }
     sleep 0.3.seconds
   end

--- a/spec/rule/ruleable_spec.cr
+++ b/spec/rule/ruleable_spec.cr
@@ -120,6 +120,8 @@ describe Alumna::Ruleable do
     r = DummyRuleable.new.after(on: :write) { |_ctx| nil }
     r.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::After).size.should eq(1)
     r.collect_rules(Alumna::ServiceMethod::Update, Alumna::RulePhase::After).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Patch, Alumna::RulePhase::After).size.should eq(1)
+    r.collect_rules(Alumna::ServiceMethod::Remove, Alumna::RulePhase::After).size.should eq(0)
     r.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::After).size.should eq(0)
   end
 

--- a/spec/schema/base_spec.cr
+++ b/spec/schema/base_spec.cr
@@ -67,6 +67,16 @@ describe Alumna::Schema do
       fd.required_on.should eq([Alumna::ServiceMethod::Create, Alumna::ServiceMethod::Update])
     end
 
+    it "normalizes single symbol" do
+      fd = Alumna::Schema.new.str("t", required_on: :patch).fields.first
+      fd.required_on.should eq([Alumna::ServiceMethod::Patch])
+    end
+
+    it "normalizes single enum" do
+      fd = Alumna::Schema.new.str("t", required_on: Alumna::ServiceMethod::Create).fields.first
+      fd.required_on.should eq([Alumna::ServiceMethod::Create])
+    end
+
     it "normalizes mixed symbols and enums" do
       fd = Alumna::Schema.new.str("t",
         required_on: [Alumna::ServiceMethod::Patch, :remove]

--- a/spec/service/base_spec.cr
+++ b/spec/service/base_spec.cr
@@ -70,7 +70,7 @@ describe "Service::Base" do
     it "yields self for rule registration" do
       schema = Alumna::Schema.new.str("x")
 
-      svc = Alumna.memory(schema) do # use the factory, not .new directly
+      svc = Alumna.memory(schema) do # use the factory, not.new directly
         before { |_c| nil }
         after { |_c| nil }
         error { |_c| nil }
@@ -101,6 +101,66 @@ describe "Service::Base" do
       svc = Alumna::MemoryAdapter.new
       svc.schema.should be_nil
       svc.collect_rules(Alumna::ServiceMethod::Find, Alumna::RulePhase::Before).should be_empty
+    end
+  end
+
+  describe "validate helper" do
+    it "builds a rule from the service schema" do
+      schema = Alumna::Schema.new.str("name", min_length: 1)
+
+      svc = Alumna.memory(schema) do
+        before validate, on: :create
+      end
+
+      rules = svc.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Before)
+      rules.size.should eq(1)
+
+      # Simulate a failing validation
+      ctx = Alumna::RuleContext.new(
+        app: Alumna::App.new,
+        service: svc,
+        path: "/test",
+        method: Alumna::ServiceMethod::Create,
+        phase: Alumna::RulePhase::Before,
+        params: Alumna::Http::ParamsView.new(HTTP::Params.new),
+        headers: Alumna::Http::HeadersView.new(HTTP::Headers.new),
+        data: {} of String => Alumna::AnyData
+      )
+
+      err = rules.first.call(ctx)
+      err.should_not be_nil
+      err.as(Alumna::ServiceError).status.should eq(422)
+    end
+
+    it "accepts an explicit schema override" do
+      schema1 = Alumna::Schema.new.str("a")
+      schema2 = Alumna::Schema.new.str("b", min_length: 1)
+
+      svc = Alumna.memory(schema1) do
+        before validate(schema2), on: :create
+      end
+
+      rules = svc.collect_rules(Alumna::ServiceMethod::Create, Alumna::RulePhase::Before)
+      ctx = Alumna::RuleContext.new(
+        app: Alumna::App.new,
+        service: svc,
+        path: "/test",
+        method: Alumna::ServiceMethod::Create,
+        phase: Alumna::RulePhase::Before,
+        params: Alumna::Http::ParamsView.new(HTTP::Params.new),
+        headers: Alumna::Http::HeadersView.new(HTTP::Headers.new),
+        data: {"b" => ""} of String => Alumna::AnyData
+      )
+
+      err = rules.first.call(ctx)
+      err.as(Alumna::ServiceError).status.should eq(422)
+    end
+
+    it "raises at boot if service has no schema" do
+      svc = Alumna::MemoryAdapter.new
+      expect_raises(ArgumentError, "validate requires a schema") do
+        svc.validate
+      end
     end
   end
 end

--- a/spec/service/context_spec.cr
+++ b/spec/service/context_spec.cr
@@ -1,0 +1,39 @@
+require "../spec_helper"
+
+describe Alumna::RuleContext do
+  describe "typed data accessors" do
+    it "returns String for data_str?" do
+      ctx = test_ctx
+      ctx.data["name"] = "Alice"
+      ctx.data_str?("name").should eq("Alice")
+      ctx.data_str?("missing").should be_nil
+    end
+
+    it "returns Int64 for data_int?" do
+      ctx = test_ctx
+      ctx.data["age"] = 30_i64
+      ctx.data_int?("age").should eq(30)
+      ctx.data_int?("missing").should be_nil
+    end
+
+    it "returns Float64 for data_float?" do
+      ctx = test_ctx
+      ctx.data["score"] = 4.5
+      ctx.data_float?("score").should eq(4.5)
+    end
+
+    it "returns Bool for data_bool?" do
+      ctx = test_ctx
+      ctx.data["active"] = true
+      ctx.data_bool?("active").should be_true
+      ctx.data_bool?("missing").should be_nil
+    end
+
+    it "returns nil when type mismatches" do
+      ctx = test_ctx
+      ctx.data["age"] = "not-a-number"
+      ctx.data_int?("age").should be_nil
+      ctx.data_bool?("age").should be_nil
+    end
+  end
+end

--- a/src/rule/ruleable.cr
+++ b/src/rule/ruleable.cr
@@ -5,6 +5,11 @@ module Alumna
     @after_rules = Hash(ServiceMethod, Array(Rule)).new { |h, k| h[k] = [] of Rule }
     @error_rules = Hash(ServiceMethod, Array(Rule)).new { |h, k| h[k] = [] of Rule }
 
+    # Explicit method sets - used at boot time only, no runtime cost
+    READ_METHODS  = [ServiceMethod::Find, ServiceMethod::Get]
+    WRITE_METHODS = [ServiceMethod::Create, ServiceMethod::Update, ServiceMethod::Patch]
+    ALL_METHODS   = ServiceMethod.values.reject(&.options?)
+
     # ---- public API ----
 
     def before(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
@@ -56,16 +61,16 @@ module Alumna
     end
 
     private def expand_on(on) : Array(ServiceMethod)
-      return ServiceMethod.values.reject(&.options?) if on.nil?
+      return ALL_METHODS if on.nil?
 
       items = on.is_a?(Array) ? on : [on]
       items.flat_map do |item|
         case item
         when ServiceMethod then [item]
-        when :read         then [ServiceMethod::Find, ServiceMethod::Get]
-        when :write        then [ServiceMethod::Create, ServiceMethod::Update, ServiceMethod::Patch, ServiceMethod::Remove]
-        when :all          then ServiceMethod.values.reject(&.options?)
-        when Symbol        then [ServiceMethod.parse(item.to_s)]
+        when :read         then READ_METHODS
+        when :write        then WRITE_METHODS
+        when :all          then ALL_METHODS
+        when Symbol        then [ServiceMethod.parse(item.to_s.capitalize)]
         else                    [] of ServiceMethod
         end
       end.uniq!

--- a/src/schema/base.cr
+++ b/src/schema/base.cr
@@ -35,7 +35,7 @@ module Alumna
       @fields = [] of FieldDescriptor
     end
 
-    # Core API — accepts Symbols for ergonomics
+    # Core API - accepts Symbols for ergonomics
     def field(
       name : String,
       type : FieldType | Symbol,
@@ -43,7 +43,7 @@ module Alumna
       min_length : Int32? = nil,
       max_length : Int32? = nil,
       format : Symbol | String | Nil = nil,
-      required_on : Array(ServiceMethod | Symbol) | Nil = nil,
+      required_on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil,
     ) : self
       # normalize :str → FieldType::Str
       field_type = type.is_a?(Symbol) ? FieldType.parse(type.to_s.capitalize) : type
@@ -69,10 +69,19 @@ module Alumna
         end
       end
 
-      # normalize :create → ServiceMethod::Create
-      norm_required_on = required_on.try &.map do |m|
-        m.is_a?(ServiceMethod) ? m : ServiceMethod.parse(m.to_s.capitalize)
-      end
+      # normalize :create → [ServiceMethod::Create], also accepts single symbol
+      norm_required_on = case required_on
+                         in Nil
+                           nil
+                         in Array
+                           required_on.map do |m|
+                             m.is_a?(ServiceMethod) ? m : ServiceMethod.parse(m.to_s.capitalize)
+                           end
+                         in ServiceMethod
+                           [required_on]
+                         in Symbol
+                           [ServiceMethod.parse(required_on.to_s.capitalize)]
+                         end
 
       @fields << FieldDescriptor.new(
         name: name,

--- a/src/service/base.cr
+++ b/src/service/base.cr
@@ -17,6 +17,19 @@ module Alumna
       @before_app_len = Array.new(size, 0)
     end
 
+    # ---- convenience helpers ----
+
+    # Returns a validation Rule for this service's schema.
+    # Use inside a service block: `before validate, on: :write`
+    # You can override with `validate(other_schema)` if needed.
+    def validate(schema : Schema? = nil) : Rule
+      s = schema || self.schema
+      raise ArgumentError.new("validate requires a schema - service has none and none was passed") unless s
+      Alumna.validate(s)
+    end
+
+    # -----------------------------
+
     abstract def find(ctx : RuleContext) : Array(Hash(String, AnyData))
     abstract def get(ctx : RuleContext) : Hash(String, AnyData)?
     abstract def create(ctx : RuleContext) : Hash(String, AnyData)

--- a/src/service/context.cr
+++ b/src/service/context.cr
@@ -2,7 +2,7 @@ require "json"
 require "http"
 
 module Alumna
-  # forward declarations — full bodies live in http/router.cr
+  # forward declarations - full bodies live in http/router.cr
   module Http
     struct ParamsView; end
 
@@ -60,6 +60,23 @@ module Alumna
 
     def result_set? : Bool
       !@result.nil?
+    end
+
+    # ---- typed data accessors (zero-cost, inlined) ----
+    def data_str?(key) : String?
+      data[key]?.as?(String)
+    end
+
+    def data_int?(key) : Int64?
+      data[key]?.as?(Int64)
+    end
+
+    def data_float?(key) : Float64?
+      data[key]?.as?(Float64)
+    end
+
+    def data_bool?(key) : Bool?
+      data[key]?.as?(Bool)
     end
   end
 


### PR DESCRIPTION
- feat: `validate` as a first-class service method
- feat: typed data accessors for simpler adapters
- feat: allow optional single verbs like `required_on: :create`, to not force an array
- fix: correct `:write` semantics