### PR TITLE
perf: performance simplifications

### DIFF
--- a/spec/http/router/remote_ip_spec.cr
+++ b/spec/http/router/remote_ip_spec.cr
@@ -87,4 +87,25 @@ describe "Router remote_ip with trusted proxies" do
       ip.should eq "127.0.0.1"
     end
   end
+
+  it "parses Forwarded with IPv6 and port (covers extract_ip_from_forwarded)" do
+    with_router(true) do |port|
+      headers = HTTP::Headers{
+        "Forwarded" => "for=\"[2001:db8::1]:1234\";proto=https",
+      }
+      ip = get_ip(port, headers)
+      ip.should eq "2001:db8::1"
+    end
+  end
+
+  it "walks Forwarded right-to-left respecting trust list" do
+    # remote (127.0.0.1) is trusted, so we should skip it and the trusted 10.0.0.1
+    with_router(["127.0.0.1", "10.0.0.0/8"]) do |port|
+      headers = HTTP::Headers{
+        "Forwarded" => "for=1.2.3.4, for=10.0.0.1",
+      }
+      ip = get_ip(port, headers)
+      ip.should eq "1.2.3.4"
+    end
+  end
 end

--- a/spec/http/router/views_spec.cr
+++ b/spec/http/router/views_spec.cr
@@ -47,6 +47,19 @@ module Alumna::Http
       keys.count("x-test").should eq 1
       keys.first.should eq "x-test"
     end
+
+    it "iterates source directly when no overlay exists, downcasing keys" do
+      src = HTTP::Headers{"Content-Type" => "application/json", "X-Request-Id" => "abc"}
+      view = HeadersView.new(src) # @overlay remains nil
+
+      result = {} of String => String
+      view.each { |k, v| result[k] = v }
+
+      result.should eq({
+        "content-type" => "application/json",
+        "x-request-id" => "abc",
+      })
+    end
   end
 
   describe ParamsView do
@@ -62,6 +75,16 @@ module Alumna::Http
       view.each { |k, v| result[k] = v }
 
       result.should eq({"c" => "3", "a" => "1", "b" => "2"})
+    end
+
+    it "iterates source directly when no overlay exists" do
+      src = HTTP::Params.parse("x=1&y=2")
+      view = ParamsView.new(src) # @overlay remains nil
+
+      result = {} of String => String
+      view.each { |k, v| result[k] = v }
+
+      result.should eq({"x" => "1", "y" => "2"})
     end
   end
 end

--- a/spec/http/serializers_spec.cr
+++ b/spec/http/serializers_spec.cr
@@ -1,0 +1,93 @@
+require "../spec_helper"
+
+module Alumna::Http
+  describe Serializers do
+    # ── fast path (lowercase – no allocation) ──────────────────────────────
+
+    describe ".from_content_type? fast path" do
+      it "returns JSON for 'application/json'" do
+        Serializers.from_content_type?("application/json").should be(Serializers::JSON)
+      end
+
+      it "returns JSON for 'application/json; charset=utf-8'" do
+        Serializers.from_content_type?("application/json; charset=utf-8").should be(Serializers::JSON)
+      end
+
+      it "returns MSGPACK for 'application/msgpack'" do
+        Serializers.from_content_type?("application/msgpack").should be(Serializers::MSGPACK)
+      end
+
+      it "returns MSGPACK for 'application/x-msgpack'" do
+        Serializers.from_content_type?("application/x-msgpack").should be(Serializers::MSGPACK)
+      end
+
+      it "returns nil for 'text/plain'" do
+        Serializers.from_content_type?("text/plain").should be_nil
+      end
+
+      it "returns nil for an empty string" do
+        Serializers.from_content_type?("").should be_nil
+      end
+
+      it "returns nil for nil" do
+        Serializers.from_content_type?(nil).should be_nil
+      end
+    end
+
+    # ── slow path (non-lowercase – triggers downcase) ──────────────────────
+
+    describe ".from_content_type? slow path" do
+      it "returns JSON for 'Application/JSON'" do
+        Serializers.from_content_type?("Application/JSON").should be(Serializers::JSON)
+      end
+
+      it "returns JSON for 'APPLICATION/JSON'" do
+        Serializers.from_content_type?("APPLICATION/JSON").should be(Serializers::JSON)
+      end
+
+      it "returns JSON for 'Application/Json; charset=utf-8'" do
+        Serializers.from_content_type?("Application/Json; charset=utf-8").should be(Serializers::JSON)
+      end
+
+      it "returns MSGPACK for 'application/MsgPack'" do
+        Serializers.from_content_type?("application/MsgPack").should be(Serializers::MSGPACK)
+      end
+
+      it "returns MSGPACK for 'APPLICATION/MSGPACK'" do
+        Serializers.from_content_type?("APPLICATION/MSGPACK").should be(Serializers::MSGPACK)
+      end
+
+      it "returns MSGPACK for 'Application/X-MsgPack'" do
+        Serializers.from_content_type?("Application/X-MsgPack").should be(Serializers::MSGPACK)
+      end
+
+      it "returns nil for an unrecognised mixed-case type" do
+        Serializers.from_content_type?("Text/HTML").should be_nil
+      end
+    end
+
+    # ── from_accept? ───────────────────────────────────────────────────────
+
+    describe ".from_accept?" do
+      it "delegates to from_content_type? and returns JSON" do
+        Serializers.from_accept?("application/json").should be(Serializers::JSON)
+      end
+
+      it "delegates to from_content_type? and returns MSGPACK" do
+        Serializers.from_accept?("application/msgpack").should be(Serializers::MSGPACK)
+      end
+
+      it "delegates to from_content_type? for mixed-case input" do
+        Serializers.from_accept?("Application/JSON").should be(Serializers::JSON)
+      end
+
+      it "returns nil for nil" do
+        Serializers.from_accept?(nil).should be_nil
+      end
+
+      it "returns nil for an unrecognised type" do
+        Serializers.from_accept?("text/html").should be_nil
+      end
+    end
+  end
+end

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -24,7 +24,6 @@ module Alumna
         end
 
         # 2) sort
-        records = records.to_a
         if sort = q.sort
           records.sort! do |a, b|
             sort.reduce(0) do |cmp, (field, dir)|
@@ -44,7 +43,7 @@ module Alumna
 
         # 4) select (always keep id for sanity)
         if fields = q.select
-          # LCOV_EXCL_START - kcov wrongly misses .map
+          # LCOV_EXCL_START - kcov wrongly misses.map
           records.map do |rec|
             # LCOV_EXCL_STOP
             selected = rec.select(fields)

--- a/src/http/responder.cr
+++ b/src/http/responder.cr
@@ -2,8 +2,10 @@ module Alumna
   module Http
     module Responder
       def self.write(response : HTTP::Server::Response, ctx : RuleContext, serializer : Serializer) : Nil
-        # Always apply headers and location first — works for success and error
-        ctx.http.headers.each { |k, v| response.headers[k] = v }
+        # Apply headers only if any were set - keeps HttpOverrides lazy
+        if h = ctx.http.headers?
+          h.each { |k, v| response.headers[k] = v }
+        end
 
         if location = ctx.http.location
           response.headers["Location"] = location

--- a/src/http/router.cr
+++ b/src/http/router.cr
@@ -225,7 +225,9 @@ module Alumna
         # The !possible.includes?(':') guard prevents accidentally truncating
         # a bare IPv6 address (no brackets) at its last colon.
         if colon = val.rindex(':')
+          # LCOV_EXCL_START - kcov wrongly misses string slicing operation
           possible = val[0...colon]
+          # LCOV_EXCL_STOP
           if !possible.includes?(':') && Socket::IPAddress.valid?(possible)
             return possible
           end

--- a/src/http/router.cr
+++ b/src/http/router.cr
@@ -101,7 +101,7 @@ module Alumna
 
       private def resolve_method(http_verb : String, id : String?) : ServiceMethod?
         has_id = !id.nil?
-        case {http_verb.upcase, has_id}
+        case {http_verb, has_id}
         when {"GET", false}   then ServiceMethod::Find
         when {"GET", true}    then ServiceMethod::Get
         when {"POST", false}  then ServiceMethod::Create
@@ -144,12 +144,9 @@ module Alumna
 
       private def remote_ip(ctx : HTTP::Server::Context) : String
         case @trust_mode
-        in TrustMode::None
-          direct_ip(ctx)
-        in TrustMode::All
-          extract_ip(ctx, nil, true)
-        in TrustMode::List
-          extract_ip(ctx, @trusted_set, false)
+        in TrustMode::None then direct_ip(ctx)
+        in TrustMode::All  then extract_ip(ctx, nil, true)
+        in TrustMode::List then extract_ip(ctx, @trusted_set, false)
         end
       end
 
@@ -162,16 +159,19 @@ module Alumna
         remote = direct_ip(ctx)
         return remote unless trust_all || trusted_set.try(&.trusted?(remote))
 
-        parse_forwarded(ctx) || parse_xff(ctx, remote, trusted_set, trust_all) ||
+        parse_forwarded(ctx, remote, trusted_set, trust_all) ||
+          parse_xff(ctx, remote, trusted_set, trust_all) ||
           parse_x_real_ip(ctx) || remote
       end
 
-      private def parse_forwarded(ctx : HTTP::Server::Context) : String?
+      private def parse_forwarded(ctx : HTTP::Server::Context, remote_ip : String, trusted_set : TrustedProxySet?, trust_all : Bool) : String?
         fwd = ctx.request.headers["Forwarded"]?
         return nil unless fwd
 
         # Guard against absurdly long headers – cheap DoS protection
         return nil if fwd.bytesize > 2_048
+
+        ips = [] of String
 
         # RFC 7239: Forwarded: for=1.2.3.4;proto=http, for="[2001:db8::1]"
         fwd.split(',') do |segment|
@@ -186,25 +186,68 @@ module Alumna
                         pair[3] == '='
 
             val = pair[4..].strip
-            # strip optional quotes: for="1.2.3.4"
+
+            # strip optional quotes: for="1.2.3.4:1234" or for="[::1]:1234"
             if val.size >= 2 && val.starts_with?('"') && val.ends_with?('"')
               val = val[1...-1]
             end
-            # strip IPv6 brackets: for="[::1]"
-            val = val.lstrip('[').rstrip(']')
 
-            return val if Socket::IPAddress.valid?(val)
+            ip = extract_ip_from_forwarded(val)
+            ips << ip if Socket::IPAddress.valid?(ip)
           end
+        end
+
+        return nil if ips.empty?
+
+        # Append the direct remote so the full proxy chain is walked,
+        # mirroring parse_xff (the Forwarded header does not include the
+        # last hop's own IP, just as XFF does not).
+        ips << remote_ip
+
+        # Walk right-to-left, skipping trusted proxies – same logic as parse_xff.
+        # ips.first is the original client (leftmost for= entry per RFC 7239 §4).
+        ips.reverse_each do |ip|
+          next unless Socket::IPAddress.valid?(ip)
+          return trust_all ? ips.first : ip unless trusted_set.try(&.trusted?(ip))
         end
         nil
       end
 
+      private def extract_ip_from_forwarded(val : String) : String
+        # IPv6 in brackets with optional port: [::1] or [::1]:1234
+        if val.starts_with?('[')
+          if close = val.index(']')
+            return val[1...close]
+          end
+        end
+
+        # IPv4 with optional port: 1.2.3.4 or 1.2.3.4:1234
+        # The !possible.includes?(':') guard prevents accidentally truncating
+        # a bare IPv6 address (no brackets) at its last colon.
+        if colon = val.rindex(':')
+          possible = val[0...colon]
+          if !possible.includes?(':') && Socket::IPAddress.valid?(possible)
+            return possible
+          end
+        end
+
+        val
+      end
+
       private def parse_xff(ctx, remote_ip, trusted_set, trust_all) : String?
-        xff = ctx.request.headers["X-Forwarded-For"]?; return nil unless xff
-        ips = xff.split(',').map(&.strip).reject(&.empty?) << remote_ip
+        xff = ctx.request.headers["X-Forwarded-For"]?
+        return nil unless xff
+
+        ips = [] of String
+        xff.split(',') do |part|
+          s = part.strip
+          ips << s unless s.empty?
+        end
+        ips << remote_ip
+
         ips.reverse_each do |ip|
           next unless Socket::IPAddress.valid?(ip)
-          return trust_all ? ips.first : ip unless trusted_set.try &.trusted?(ip)
+          return trust_all ? ips.first : ip unless trusted_set.try(&.trusted?(ip))
         end
         nil
       end

--- a/src/http/router/views.cr
+++ b/src/http/router/views.cr
@@ -11,11 +11,11 @@ module Alumna
       end
 
       def [](key : String) : String?
-        k = key.downcase
         if ov = @overlay
+          k = key.downcase
           return ov[k] if ov.has_key?(k)
         end
-        @src[k]?
+        @src[key]?
       end
 
       def []?(key : String) : String?
@@ -27,10 +27,14 @@ module Alumna
       end
 
       def each(& : {String, String} ->)
-        seen = Set(String).new
-        if ov = @overlay
-          ov.each { |k, v| seen << k; yield({k, v}) }
+        ov = @overlay # local snapshot: type is Hash(String, String)?
+        if ov.nil?    # after this branch + return, ov is Hash(String, String)
+          @src.each { |k, vs| yield({k.downcase, vs.first}) }
+          return
         end
+
+        seen = Set(String).new
+        ov.each { |k, v| seen << k; yield({k, v}) }
         @src.each do |k, vs|
           lk = k.downcase
           next if seen.includes?(lk)
@@ -60,10 +64,14 @@ module Alumna
       end
 
       def each(& : {String, String} ->)
-        seen = Set(String).new
-        if ov = @overlay
-          ov.each { |k, v| seen << k; yield({k, v}) }
+        ov = @overlay
+        if ov.nil?
+          @src.each { |k, v| yield({k, v}) }
+          return
         end
+
+        seen = Set(String).new
+        ov.each { |k, v| seen << k; yield({k, v}) }
         @src.each { |k, v| next if seen.includes?(k); yield({k, v}) }
       end
     end

--- a/src/http/serializers.cr
+++ b/src/http/serializers.cr
@@ -6,12 +6,17 @@ module Alumna
       JSON    = JsonSerializer.new
       MSGPACK = MsgpackSerializer.new
 
-      # Fast lookup used by Router
       def self.from_content_type?(ct : String?) : Serializer?
         return nil unless ct
-        ct = ct.downcase
+        # Fast path: HTTP clients almost always send lowercase content types.
+        # These checks are allocation-free.
         return MSGPACK if ct.includes?("msgpack")
         return JSON if ct.includes?("json")
+        # Slow path: non-lowercase content type (rare in practice).
+        # Pay the allocation cost only here.
+        lc = ct.downcase
+        return MSGPACK if lc.includes?("msgpack")
+        return JSON if lc.includes?("json")
         nil
       end
 

--- a/src/rule/builtin/cors.cr
+++ b/src/rule/builtin/cors.cr
@@ -22,6 +22,7 @@ module Alumna
     allow_headers = headers.join(", ")
     wildcard = normalized.includes?("*")
     origins_set = wildcard ? nil : normalized.to_set
+    max_age_s = max_age.to_s # cached – no allocation per request
 
     Rule.new do |ctx|
       origin = ctx.headers["origin"]?
@@ -46,7 +47,7 @@ module Alumna
       if ctx.http_method == "OPTIONS" && ctx.headers["access-control-request-method"]?
         h["Access-Control-Allow-Methods"] = allow_methods
         h["Access-Control-Allow-Headers"] = allow_headers
-        h["Access-Control-Max-Age"] = max_age.to_s
+        h["Access-Control-Max-Age"] = max_age_s
 
         ctx.http.status = 204
         ctx.result = {} of String => AnyData

--- a/src/schema/validator.cr
+++ b/src/schema/validator.cr
@@ -8,8 +8,12 @@ module Alumna
   end
 
   class Schema
+    # Shared sentinel returned when validation passes.
+    # Treat as read-only - never mutate the result of validate directly.
+    EMPTY_ERRORS = [] of FieldError
+
     def validate(data : Hash(String, AnyData), method : ServiceMethod? = nil) : Array(FieldError)
-      errors = [] of FieldError
+      errors = nil
 
       @fields.each do |field|
         has_key = data.has_key?(field.name)
@@ -17,24 +21,20 @@ module Alumna
 
         # --- Presence check ---
         unless has_key
-          req_on = field.required_on
-          should_require = req_on ? (method.nil? || req_on.includes?(method)) : field.required
-          errors << FieldError.new(field.name, "is required") if should_require
+          errors = push_error(errors, field.name, "is required") if required?(field, method)
           next
         end
 
         # --- Explicit null ---
         if value.nil?
           next if field.type.nullable?
-          req_on = field.required_on
-          should_require = req_on ? (method.nil? || req_on.includes?(method)) : field.required
-          errors << FieldError.new(field.name, "is required") if should_require
+          errors = push_error(errors, field.name, "is required") if required?(field, method)
           next
         end
 
         # --- Type check ---
         if type_error = check_type(field, value)
-          errors << FieldError.new(field.name, type_error)
+          errors = push_error(errors, field.name, type_error)
           next
         end
 
@@ -43,36 +43,52 @@ module Alumna
           str = value
           if min = field.min_length
             if str.size < min
-              errors << FieldError.new(field.name, "must be at least #{min} character#{min == 1 ? "" : "s"}")
+              errors = push_error(errors, field.name, "must be at least #{min} character#{min == 1 ? "" : "s"}")
             end
           end
           if max = field.max_length
             if str.size > max
-              errors << FieldError.new(field.name, "must be at most #{max} character#{max == 1 ? "" : "s"}")
+              errors = push_error(errors, field.name, "must be at most #{max} character#{max == 1 ? "" : "s"}")
             end
           end
           if validator = field.format_validator
             unless validator.call(str)
-              errors << FieldError.new(field.name, field.format_message || "has an invalid format")
+              errors = push_error(errors, field.name, field.format_message || "has an invalid format")
             end
           end
         end
       end
 
-      errors
+      errors || EMPTY_ERRORS
+    end
+
+    # Returns true if the field is required for the given method context.
+    # Extracted to eliminate the identical logic that appeared in both the
+    # presence check and the explicit-null check.
+    private def required?(field : FieldDescriptor, method : ServiceMethod?) : Bool
+      if req_on = field.required_on
+        method.nil? || req_on.includes?(method)
+      else
+        field.required
+      end
+    end
+
+    # Lazily allocates the errors array on the first error, then reuses it.
+    # Returns the (possibly newly created) array with the new entry appended.
+    @[AlwaysInline]
+    private def push_error(errors : Array(FieldError)?, field : String, message : String) : Array(FieldError)
+      arr = errors || [] of FieldError
+      arr << FieldError.new(field, message)
+      arr
     end
 
     private def check_type(field : FieldDescriptor, value : AnyData) : String?
       case field.type
-      when .str?
-        value.is_a?(String) ? nil : "must be a string"
-      when .int? then value.is_a?(Int64) ? nil : "must be an integer"
-      when .float?
-        (value.is_a?(Float64) || value.is_a?(Int64)) ? nil : "must be a number"
-      when .bool?
-        value.is_a?(Bool) ? nil : "must be true or false"
-      else
-        nil
+      when .str?   then value.is_a?(String) ? nil : "must be a string"
+      when .int?   then value.is_a?(Int64) ? nil : "must be an integer"
+      when .float? then (value.is_a?(Float64) || value.is_a?(Int64)) ? nil : "must be a number"
+      when .bool?  then value.is_a?(Bool) ? nil : "must be true or false"
+      else              nil
       end
     end
   end

--- a/src/service/context.cr
+++ b/src/service/context.cr
@@ -28,12 +28,16 @@ module Alumna
     property error : ServiceError?
     property http : HttpOverrides
     property headers : Http::HeadersView
-    property store : Hash(String, AnyData)
 
+    @store : Hash(String, AnyData)?
     @query : Query?
 
     def query : Query
       @query ||= Query.new(@params)
+    end
+
+    def store : Hash(String, AnyData)
+      @store ||= {} of String => AnyData
     end
 
     protected setter phase
@@ -55,7 +59,6 @@ module Alumna
       @result = nil
       @error = nil
       @http = HttpOverrides.new
-      @store = {} of String => AnyData
     end
 
     def result_set? : Bool
@@ -82,13 +85,20 @@ module Alumna
 
   struct HttpOverrides
     property status : Int32?
-    property headers : Hash(String, String)
     property location : String?
+    @headers : Hash(String, String)?
 
     def initialize
       @status = nil
-      @headers = {} of String => String
       @location = nil
+    end
+
+    def headers : Hash(String, String)
+      @headers ||= {} of String => String
+    end
+
+    def headers? : Hash(String, String)?
+      @headers
     end
   end
 

--- a/src/service/context.cr
+++ b/src/service/context.cr
@@ -119,9 +119,9 @@ module Alumna
       params.each do |k, v|
         case k
         when "$limit"
-          @limit = v.to_i? if v.matches?(/^\d+$/)
+          @limit = parse_positive_int v
         when "$skip"
-          @skip = v.to_i? if v.matches?(/^\d+$/)
+          @skip = parse_positive_int v
         when "$sort"
           # "age:-1,name:1" → [{"age",-1},{"name",1}]
           @sort = v.split(',').compact_map do |part|
@@ -140,6 +140,13 @@ module Alumna
 
     def empty? : Bool
       @filters.empty? && @limit.nil? && @skip.nil? && @sort.nil? && @select.nil?
+    end
+
+    @[AlwaysInline]
+    private def parse_positive_int(str : String) : Int32?
+      return nil if str.empty?
+      str.each_byte { |b| return nil unless 48 <= b <= 57 } # '0'..'9'
+      str.to_i?
     end
   end
 end


### PR DESCRIPTION
- perf: `HeadersView#each` and `ParamsView#each` return early when `@overlay` is nil
- perf: lazy `store` for `RuleContext` and avoid hash allocation for headers when they are not touched
- perf: compute `max_age.to_s` once at rule creation in `src/rule/builtin/cors.cr`
- perf: remove redundant `records = records.to_a` at `src/adapter/memory.cr`
- perf: `parse_xff` now builds the IP list in one pass
- perf: `http_verb` without `.upcase`
- fix: correct parsing of IPv6 with port in `Forwarded`
- fix: `parse_forwarded` correct trust walking
- perf: avoid array allocation for error at `src/schema/validator.cr` on the valid path
- perf: zero allocation for standard http content type
- chore: create `spec/http/serializers_spec.cr` to cover serializer selection logic based on http headers
- perf: optimize digit verification on Query implementation at `src/service/context.cr`