### PR TITLE
chore/perf: solid foundation - part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,24 @@
 name: Crystal CI
 
-on: [push, pull_request]
+on:
+  # Triggers when a PR is opened or updated
+  pull_request:
+    branches:
+      - main
+
+  # Triggers when code is merged to main, OR directly pushed to main
+  push:
+    branches:
+      - main
+    # Do not trigger a run if the ONLY changes are to these files:
+    paths-ignore:
+      - '**.md'      # Ignores README.md, CHANGELOG.md, etc.
+      - 'LICENSE'
+
+# Automatically cancel in-progress runs if a new commit is pushed to the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-latest]
-        crystal: [latest, nightly]
+        os: [ubuntu-latest]
+        crystal: [latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
   # Triggers when a PR is opened or updated
   pull_request:
     branches:
-      - main
+      - master
 
   # Triggers when code is merged to main, OR directly pushed to main
   push:
     branches:
-      - main
+      - master
     # Do not trigger a run if the ONLY changes are to these files:
     paths-ignore:
       - '**.md'      # Ignores README.md, CHANGELOG.md, etc.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-crystal-${{ matrix.crystal }}-shards-
       - run: shards install
-      - run: crystal spec --error-trace --verbose
       - run: crystal tool format --check
+
+      # 1. Run standard (Single-Threaded) tests
+      - name: Run specs (Single-Threaded)
+        run: crystal spec --error-trace --verbose
+
+      # 2. Run Execution Context (Multi-Threaded) tests
+      - name: Run specs (Multi-Threaded)
+        run: crystal spec -Dpreview_mt -Dexecution_context --error-trace --verbose
 
   coverage:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -674,32 +674,32 @@ class PostgresUserService < Alumna::Service
     self.before(Authenticate)
   end
 
-  def find(ctx : RuleContext) : Array(Hash(String, AnyData))
+  def find(ctx : RuleContext) : Array(Hash(String, AnyData)) | ServiceError
     # query @db using ctx.query.filters, limit, skip, and sort
     [] of Hash(String, AnyData)
   end
 
-  def get(ctx : RuleContext) : Hash(String, AnyData)?
+  def get(ctx : RuleContext) : Hash(String, AnyData)? | ServiceError
     # query @db using ctx.id
     nil
   end
 
-  def create(ctx : RuleContext) : Hash(String, AnyData)
+  def create(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
     # insert ctx.data into @db, return the created record
     {} of String => AnyData
   end
 
-  def update(ctx : RuleContext) : Hash(String, AnyData)
+  def update(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
     # full replace of ctx.id with ctx.data
     {} of String => AnyData
   end
 
-  def patch(ctx : RuleContext) : Hash(String, AnyData)
+  def patch(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
     # partial update of ctx.id with ctx.data
     {} of String => AnyData
   end
 
-  def remove(ctx : RuleContext) : Bool
+  def remove(ctx : RuleContext) : Bool | ServiceError
     # delete record at ctx.id, return true if deleted
     false
   end

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Alumna is in active early development. The following core pieces are complete an
 - ✅ In-memory adapter implementing the full service interface
 - ✅ JSON and MessagePack serialization
 - ✅ Rich `RuleContext` with `store`, `remote_ip` (with trusted proxy support), `http_method`, `headers`, and `provider`
-- ✅ Query parsing (`$limit`, `$skip`, `$sort`, `$select`) via `ctx.query`
+- ✅ Rich query parsing (`$limit`, `$skip`, `$sort`, `$select`, `$in`, `$gt`, etc.) via `ctx.query` with deep dot-notation support
 - ✅ Path normalization and duplicate-route protection
 - ✅ Strict request-body limits enforced on all IO entry points
 - ✅ Cross-platform CI with full test coverage
@@ -488,6 +488,26 @@ ServiceError.internal("message")               # 500
 
 ---
 
+### Querying
+
+Alumna automatically parses URL query strings into a strongly-typed `ctx.query` object. It natively supports FeathersJS/MongoDB-style comparison operators and nested dot-notation.
+
+```crystal
+# GET /users?age[$gte]=18&status[$in]=active,pending&billing.plan=pro&$limit=10&$sort=age:-1
+
+ctx.query.filters["age"]          # => [{op: Op::Gte, value: "18"}]
+ctx.query.filters["status"]       # => [{op: Op::In, value: ["active", "pending"]}]
+ctx.query.filters["billing.plan"] # => [{op: Op::Eq, value: "pro"}]
+ctx.query.limit                   # => 10
+ctx.query.sort                    # => [{"age", -1}]
+```
+
+**Supported comparison operators:** `$eq` (default), `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`.
+
+The built-in `MemoryAdapter` implements all of these out of the box—correctly applying operators, distributing array matching, and resolving nested fields. When building custom database adapters, you read `ctx.query` to effortlessly compile the equivalent SQL or NoSQL statements.
+
+---
+
 ### Services
 
 A service inherits from `Alumna::MemoryAdapter` (or from `Alumna::Service` directly) and registers its rules in the constructor.
@@ -655,7 +675,7 @@ class PostgresUserService < Alumna::Service
   end
 
   def find(ctx : RuleContext) : Array(Hash(String, AnyData))
-    # query @db using ctx.params for filtering
+    # query @db using ctx.query.filters, limit, skip, and sort
     [] of Hash(String, AnyData)
   end
 

--- a/README.md
+++ b/README.md
@@ -790,41 +790,36 @@ If you are writing a custom database adapter, you can also use `Alumna::Testing:
 
 ## Roadmap
 
-### v0.5 - Security and authentication
+### v0.6 - Security and authentication
 - JWT authentication helper rule
 - session authentication helper rule
 
-### v0.6 - First real database adapter: SQLite
+### v0.7 - First real database adapter: SQLite
 - SQLite adapter for lightweight single-file deployments
 - Using [crystal-sqlite3](https://github.com/crystal-lang/crystal-sqlite3)
 - Adapter reads the service schema to introspect column names and types
 - Supports schema-driven migration hints (not full migration management, which is left to dedicated tools)
 
-### v0.7 - MySQl and PostgreSQL database adapters
+### v0.8 - MySQl and PostgreSQL database adapters
 - MySQl adapter using [crystal-db](https://github.com/crystal-lang/crystal-db) and [crystal-mysql](https://github.com/crystal-lang/crystal-mysql)
 - PostgreSQL adapter using [crystal-db](https://github.com/crystal-lang/crystal-db) and [crystal-pg](https://github.com/will/crystal-pg)
 - Adapter reads the service schema to introspect column names and types
 - Supports schema-driven migration hints (not full migration management, which is left to dedicated tools)
 
-### v0.8 - Real-time events via WebSocket
+### v0.9 - Real-time events via WebSocket
 - Emit service events automatically after successful mutations (`created`, `updated`, `patched`, `removed`)
 - Allow clients to subscribe to specific service paths over a WebSocket connection
 - Rules gain access to an `event` field on the context to suppress or transform events before they are emitted
 - Provider field on context already distinguishes `"rest"` from `"websocket"` in preparation for this
 
-### v0.9 - Redis adapter for cache
+### v0.10 - Redis adapter for cache
 - Redis adapter using [jgaskins/redis](https://github.com/jgaskins/redis)
 
-### v0.10 - NATS integration for horizontal scaling
+### v0.11 - NATS integration for horizontal scaling
 - Stateless service instances publish events to NATS subjects mirroring the service path and method (e.g. `alumna.users.created`)
 - WebSocket gateway subscribes to NATS and fans events out to connected clients
 - Enables multiple Alumna instances behind a load balancer to correctly propagate real-time events across all nodes
 - NATS chosen over AMQP for operational simplicity and natural subject-based routing
-
-### v0.11 - Automated test helpers
-- `Alumna::Testing::ServiceClient` - call service methods directly without an HTTP layer, for fast unit tests
-- `Alumna::Testing::RuleRunner` - execute a single rule against a fabricated context and assert on the result
-- Spec helpers for asserting on context state after dispatch
 
 
 
@@ -850,6 +845,9 @@ alias ServiceResult = Hash(String, AnyData) | Array(Hash(String, AnyData)) | Nil
 ```
 
 This lets every layer - context, services, rules, and serializers - work with native Crystal values instead of a wrapper type. The responder can dispatch on the actual type, MessagePack serializes without unwrapping, and validation errors flow through as plain hashes. It removes the `JSON::Any` dependency from the core, makes the context format-agnostic, and gives the compiler full visibility into data shapes for better errors and zero-cost abstractions.
+
+**Why is `ServiceError` a struct instead of an Exception?** 
+In many frameworks, returning a `404 Not Found` or a `422 Unprocessable Entity` involves raising an exception. In Crystal, instantiating an `Exception` allocates a call stack (backtrace), which adds measurable overhead under high load. By making `ServiceError` a lightweight `struct` returned directly by rules and service methods as a union type (e.g., `Hash | ServiceError`), Alumna achieves zero-allocation error paths. Expected API control flow (like a missing record or invalid input) never triggers the exception unwinding machinery, keeping throughput extremely high while remaining completely type-safe.
 
 **Why Crystal?** Expressive syntax that lowers the barrier for developers coming from Ruby or TypeScript. AOT compilation and a single binary output that eliminates runtime dependency management at deploy time. Performance that competes with Go, C and Rust _(see [LangArena](https://kostya.github.io/LangArena/))_ without sacrificing readability. The type system catches a large class of bugs at compile time that dynamic languages surface only in production.
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,38 @@ UserSchema = Alumna::Schema.new
   .field("admin", :bool, required: false)
 ```
 
-**Supported field types:** `:str`, `:int`, `:float`, `:bool`, `:nullable` (or `Alumna::FieldType::Str`, etc.)
+**Supported field types:** `:str`, `:int`, `:float`, `:bool`, `:nullable`, `:hash`, `:array` (or `Alumna::FieldType::Str`, etc.)
 
 **Supported formats:** `:email`, `:url`, `:uuid` - these are built-in and backed by Crystal's stdlib (`URI.parse`, `UUID.parse`). Formats are resolved once when the schema is defined, so validation is a direct Proc call with no hash lookups at runtime.
 
 **Supported constraints:** `required`, `required_on`, `min_length`, `max_length`, `format`
+
+#### Nested fields (Objects and Arrays)
+
+Alumna fully supports validating nested JSON structures. You can define nested objects (`hash`) and arrays of either primitives or objects. 
+
+Under the hood, the validation engine walks the data tree using a zero-allocation path tracer, ensuring that deep validation remains incredibly fast.
+
+```crystal
+OrganizationSchema = Alumna::Schema.new
+  .str("name")
+  # Nested object
+  .hash("billing") do |sub|
+    sub.str("plan", min_length: 1)
+    sub.str("card_last_four", min_length: 4, max_length: 4)
+  end
+  # Array of primitives (min_length and max_length check the array's size)
+  .array("tags", of: :str, min_length: 1, max_length: 10)
+  # Array of nested objects
+  .array("members") do |sub|
+    sub.str("email", format: :email)
+    sub.str("role")
+  end
+```
+
+When a nested field fails validation, Alumna uses standard dot/bracket notation to explicitly tell the client exactly where the error occurred (e.g., `{"billing.plan": "is required"}`, or `{"members[0].email": "must be a valid email address"}`).
+
+#### Conditional Requirements
 
 `required_on` lets a field be required only for specific operations - perfect for PATCH:
 

--- a/spec/app/listen_spec.cr
+++ b/spec/app/listen_spec.cr
@@ -87,4 +87,49 @@ describe "App#close and graceful shutdown" do
     # Proof 2: The listen loop unblocked and gracefully exited.
     listen_done.receive
   end
+
+  describe "App signals and graceful shutdown" do
+    it "traps SIGINT to trigger shutdown" do
+      app = Alumna::App.new
+      port = 34569
+      listen_done = Channel(Nil).new
+
+      spawn do
+        # trap_signals is true by default, but we pass it explicitly for clarity
+        app.listen(port, host: "127.0.0.1", trap_signals: true)
+        listen_done.send(nil)
+      end
+
+      # Wait for the server to be fully booted. This guarantees that
+      # Signal::INT.trap has already been successfully registered.
+      wait_for_port("127.0.0.1", port)
+
+      # Send SIGINT (Ctrl+C) to the current process (the spec runner).
+      # Because we trapped it, this will safely invoke our `trap_handler`,
+      # print the shutdown message, and call `app.close` without killing the test suite!
+      Process.signal(Signal::INT, Process.pid)
+
+      # The listener should unblock and finish gracefully
+      listen_done.receive
+    end
+
+    it "traps SIGTERM to trigger shutdown" do
+      app = Alumna::App.new
+      port = 34570
+      listen_done = Channel(Nil).new
+
+      spawn do
+        app.listen(port, host: "127.0.0.1", trap_signals: true)
+        listen_done.send(nil)
+      end
+
+      wait_for_port("127.0.0.1", port)
+
+      # Send SIGTERM. This ensures the second block in `src/app.cr` is covered.
+      Process.signal(Signal::TERM, Process.pid)
+
+      # The listener should unblock and finish gracefully
+      listen_done.receive
+    end
+  end
 end

--- a/spec/app/listen_spec.cr
+++ b/spec/app/listen_spec.cr
@@ -25,7 +25,7 @@ describe "App#listen" do
     # We bind to 0.0.0.0 specifically to trigger the STDERR warning
     # internally, ensuring 100% coverage of the App#listen method.
     spawn do
-      app.listen(port, host: "0.0.0.0")
+      app.listen(port, host: "0.0.0.0", trap_signals: false)
     end
 
     # Wait the server boot
@@ -34,5 +34,51 @@ describe "App#listen" do
     # Make one real TCP HTTP request to prove the listener works
     res = HTTP::Client.get("http://127.0.0.1:#{port}/listen-test")
     res.status_code.should eq(200)
+
+    app.close
+  end
+end
+
+describe "App#close and graceful shutdown" do
+  it "waits for active requests to finish before returning from listen" do
+    app = Alumna::App.new
+    request_started = Channel(Nil).new # ← synchronization point
+
+    app.use "/slow", Alumna.memory(Alumna::Schema.new) {
+      before do |ctx|
+        request_started.send(nil) # ← fires after @active_requests.add(1)
+        sleep 0.5.seconds
+        ctx.result = {"ok" => true} of String => Alumna::AnyData
+        nil
+      end
+    }
+
+    port = 34568
+    listen_done = Channel(Nil).new
+    spawn do
+      app.listen(port, host: "127.0.0.1", shutdown_timeout: 2.seconds, trap_signals: false)
+      listen_done.send(nil)
+    end
+
+    wait_for_port("127.0.0.1", port)
+
+    req_done = Channel(Int32).new
+    spawn do
+      res = HTTP::Client.get("http://127.0.0.1:#{port}/slow")
+      req_done.send(res.status_code)
+    end
+
+    request_started.receive # ← blocks until @active_requests is already 1
+
+    app.close
+
+    select
+    when status = req_done.receive
+      status.should eq(200)
+    when listen_done.receive
+      fail "listen returned before the active request finished"
+    end
+
+    listen_done.receive
   end
 end

--- a/spec/app/listen_spec.cr
+++ b/spec/app/listen_spec.cr
@@ -42,7 +42,7 @@ end
 describe "App#close and graceful shutdown" do
   it "waits for active requests to finish before returning from listen" do
     app = Alumna::App.new
-    request_started = Channel(Nil).new # ← synchronization point
+    request_started = Channel(Nil).new
 
     app.use "/slow", Alumna.memory(Alumna::Schema.new) {
       before do |ctx|
@@ -62,23 +62,29 @@ describe "App#close and graceful shutdown" do
 
     wait_for_port("127.0.0.1", port)
 
-    req_done = Channel(Int32).new
+    # We use a union type in case a forceful shutdown causes an IO::Error
+    req_done = Channel(Int32 | Exception).new
     spawn do
-      res = HTTP::Client.get("http://127.0.0.1:#{port}/slow")
-      req_done.send(res.status_code)
+      begin
+        res = HTTP::Client.get("http://127.0.0.1:#{port}/slow")
+        req_done.send(res.status_code)
+      rescue ex
+        req_done.send(ex)
+      end
     end
 
-    request_started.receive # ← blocks until @active_requests is already 1
+    # Blocks until @active_requests is guaranteed to be 1
+    request_started.receive
 
+    # Trigger shutdown while the request is actively sleeping
     app.close
 
-    select
-    when status = req_done.receive
-      status.should eq(200)
-    when listen_done.receive
-      fail "listen returned before the active request finished"
-    end
+    # Proof 1: Graceful shutdown worked because the request completed normally.
+    # If app.close killed the socket, this would be an Exception (e.g. IO::Error).
+    result = req_done.receive
+    result.should eq(200)
 
+    # Proof 2: The listen loop unblocked and gracefully exited.
     listen_done.receive
   end
 end

--- a/spec/app/listen_spec.cr
+++ b/spec/app/listen_spec.cr
@@ -131,5 +131,55 @@ describe "App#close and graceful shutdown" do
       # The listener should unblock and finish gracefully
       listen_done.receive
     end
+
+    it "exits and prints a warning if the shutdown timeout is reached" do
+      app = Alumna::App.new
+      request_started = Channel(Nil).new
+      request_finished = Channel(Nil).new
+
+      # A route that takes 0.5 seconds to process
+      app.use "/timeout", Alumna.memory(Alumna::Schema.new) {
+        before do |ctx|
+          request_started.send(nil)
+          sleep 0.1.seconds
+          request_finished.send(nil)
+
+          ctx.result = {"ok" => true} of String => Alumna::AnyData
+          nil
+        end
+      }
+
+      port = 34571
+      listen_done = Channel(Nil).new
+      spawn do
+        # Configure a very short timeout: 0.1 seconds
+        app.listen(port, host: "127.0.0.1", shutdown_timeout: 0.01.seconds, trap_signals: false)
+        listen_done.send(nil)
+      end
+
+      wait_for_port("127.0.0.1", port)
+
+      spawn do
+        begin
+          HTTP::Client.get("http://127.0.0.1:#{port}/timeout")
+        rescue
+          # We don't care about the client result here, just that it triggered the route
+        end
+      end
+
+      # 1. Wait until the request is inside the `before` block (counter is now 1)
+      request_started.receive
+
+      # 2. Trigger shutdown. The server will wait, but ONLY for 0.1 seconds.
+      app.close
+
+      # 3. This will unblock after ~0.1 seconds because the timeout is reached.
+      # It will hit the branch: puts "Shutdown timeout reached. Exiting with #{rem} active requests."
+      listen_done.receive
+
+      # 4. Clean up: wait for the sleeping request to finish so we don't leak
+      # background fibers into other tests.
+      request_finished.receive
+    end
   end
 end

--- a/spec/http/json_serializer_spec.cr
+++ b/spec/http/json_serializer_spec.cr
@@ -11,7 +11,7 @@ private def roundtrip(hash : Hash(String, Alumna::AnyData)) : Hash(String, Alumn
   io = IO::Memory.new
   json_serializer.encode(hash, io)
   io.rewind
-  json_serializer.decode(io)
+  json_serializer.decode(io).as(Hash(String, Alumna::AnyData))
 end
 
 # Encodes a hash and returns the raw JSON string for structural assertions.
@@ -108,14 +108,20 @@ describe Alumna::Http::JsonSerializer do
   # ── decode: malformed input ───────────────────────────────────────────────────
 
   describe "#decode with malformed input" do
-    it "raises ServiceError for invalid JSON" do
+    it "returns ServiceError for invalid JSON" do
       io = IO::Memory.new("not valid json")
-      expect_raises(Alumna::ServiceError) { json_serializer.decode(io) }
+      result = json_serializer.decode(io)
+
+      result.should be_a(Alumna::ServiceError)
+      result.as(Alumna::ServiceError).status.should eq(400)
     end
 
-    it "raises ServiceError for an empty body" do
+    it "returns ServiceError for an empty body" do
       io = IO::Memory.new("")
-      expect_raises(Alumna::ServiceError) { json_serializer.decode(io) }
+      result = json_serializer.decode(io)
+
+      result.should be_a(Alumna::ServiceError)
+      result.as(Alumna::ServiceError).status.should eq(400)
     end
   end
 end

--- a/spec/http/msgpack_serializer_spec.cr
+++ b/spec/http/msgpack_serializer_spec.cr
@@ -11,7 +11,7 @@ private def roundtrip(hash : Hash(String, Alumna::AnyData)) : Hash(String, Alumn
   io = IO::Memory.new
   msgpack_serializer.encode(hash, io)
   io.rewind
-  msgpack_serializer.decode(io)
+  msgpack_serializer.decode(io).as(Hash(String, Alumna::AnyData))
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -100,14 +100,20 @@ describe Alumna::Http::MsgpackSerializer do
   # ── decode: malformed input ───────────────────────────────────────────────────
 
   describe "#decode with malformed input" do
-    it "returns an empty hash for garbage bytes" do
+    it "returns a ServiceError for garbage bytes" do
       io = IO::Memory.new(Bytes[0xFF, 0xFE, 0x00, 0x01])
-      expect_raises(Alumna::ServiceError) { msgpack_serializer.decode(io) }
+      result = msgpack_serializer.decode(io)
+
+      result.should be_a(Alumna::ServiceError)
+      result.as(Alumna::ServiceError).status.should eq(400)
     end
 
-    it "raises ServiceError for an empty body" do
+    it "returns a ServiceError for an empty body" do
       io = IO::Memory.new
-      expect_raises(Alumna::ServiceError) { msgpack_serializer.decode(io) }
+      result = msgpack_serializer.decode(io)
+
+      result.should be_a(Alumna::ServiceError)
+      result.as(Alumna::ServiceError).status.should eq(400)
     end
   end
 

--- a/spec/http/router/remote_ip_spec.cr
+++ b/spec/http/router/remote_ip_spec.cr
@@ -8,7 +8,7 @@ class IpEchoService < Alumna::MemoryAdapter
     super(Alumna::Schema.new)
   end
 
-  def find(ctx) : Array(Hash(String, Alumna::AnyData))
+  def find(ctx) : Array(Hash(String, Alumna::AnyData)) | Alumna::ServiceError
     [{"ip" => ctx.remote_ip} of String => Alumna::AnyData]
   end
 end

--- a/spec/integration/app_nested_spec.cr
+++ b/spec/integration/app_nested_spec.cr
@@ -1,0 +1,164 @@
+require "../spec_helper"
+require "../../src/testing"
+
+# 1. Define a complex schema with all nested features
+OrganizationSchema = Alumna::Schema.new
+  .str("name")
+  .hash("billing") do |sub|
+    sub.str("plan")
+    sub.int("card_last_four", required: false)
+  end
+  .array("tags", of: :str, min_length: 1, max_length: 3)
+  .array("members") do |sub|
+    sub.str("email", format: :email)
+    sub.str("role")
+  end
+
+# 2. Spin up a test application
+APP_NESTED = Alumna::App.new.tap do |app|
+  app.use("/orgs", Alumna.memory(OrganizationSchema) {
+    # Run the built-in validation rule on create, update, and patch
+    before validate, on: :write
+  })
+end
+
+# 3. Helper for our test client
+def nested_client
+  Alumna::Testing::AppClient.new(APP_NESTED).tap do |c|
+    c.default_headers["Content-Type"] = "application/json"
+  end
+end
+
+describe "Alumna Integration: Nested Fields" do
+  it "creates a valid record with deep nesting" do
+    valid_payload = {
+      "name"    => "Acme Corp",
+      "billing" => {
+        "plan"           => "enterprise",
+        "card_last_four" => 4242_i64,
+      },
+      "tags"    => ["b2b", "saas"],
+      "members" => [
+        {"email" => "alice@acme.com", "role" => "admin"},
+        {"email" => "bob@acme.com", "role" => "editor"},
+      ],
+    }
+
+    res = nested_client.post("/orgs", body: valid_payload.to_json)
+
+    res.status.should eq(201)
+
+    # Ensure data was persisted correctly
+    data = res.json
+    data["id"].as_s.should match(/^\d+$/)
+    data["name"].as_s.should eq("Acme Corp")
+    data["billing"]["plan"].as_s.should eq("enterprise")
+    data["tags"][1].as_s.should eq("saas")
+    data["members"][0]["email"].as_s.should eq("alice@acme.com")
+  end
+
+  it "returns dot-notation errors for invalid nested hashes" do
+    invalid_payload = {
+      "name"    => "Acme Corp",
+      "billing" => {
+        # missing "plan"
+        "card_last_four" => "not-a-number", # wrong type
+      },
+      "tags"    => ["b2b"],
+      "members" => [] of String,
+    }
+
+    res = nested_client.post("/orgs", body: invalid_payload.to_json)
+
+    res.status.should eq(422)
+    details = res.json["details"]
+
+    details["billing.plan"].as_s.should eq("is required")
+    details["billing.card_last_four"].as_s.should eq("must be an integer")
+  end
+
+  it "returns bracket-notation errors for invalid array items (primitives)" do
+    invalid_payload = {
+      "name"    => "Acme Corp",
+      "billing" => {"plan" => "pro"},
+      "tags"    => ["valid", 123_i64, true], # index 1 and 2 are invalid
+      "members" => [] of String,
+    }
+
+    res = nested_client.post("/orgs", body: invalid_payload.to_json)
+
+    res.status.should eq(422)
+    details = res.json["details"]
+
+    details["tags[1]"].as_s.should eq("must be a string")
+    details["tags[2]"].as_s.should eq("must be a string")
+  end
+
+  it "validates constraints applied directly to the array (min_length/max_length)" do
+    invalid_payload = {
+      "name"    => "Acme Corp",
+      "billing" => {"plan" => "pro"},
+      "tags"    => [] of String, # violates min_length: 1
+      "members" => [] of String,
+    }
+
+    res = nested_client.post("/orgs", body: invalid_payload.to_json)
+
+    res.status.should eq(422)
+    details = res.json["details"]
+
+    # Error should be on the array itself, not an index
+    details["tags"].as_s.should eq("must contain at least 1 item")
+  end
+
+  it "returns dot-and-bracket notation errors for invalid array of objects" do
+    invalid_payload = {
+      "name"    => "Acme Corp",
+      "billing" => {"plan" => "pro"},
+      "tags"    => ["tech"],
+      "members" => [
+        {"email" => "alice@acme.com", "role" => "admin"}, # valid
+        {"email" => "not-an-email", "role" => "editor"},  # invalid format
+        {"role" => "viewer"},                             # missing required field
+      ],
+    }
+
+    res = nested_client.post("/orgs", body: invalid_payload.to_json)
+
+    res.status.should eq(422)
+    details = res.json["details"]
+
+    details["members[1].email"].as_s.should eq("must be a valid email address")
+    details["members[2].email"].as_s.should eq("is required")
+  end
+
+  it "catches when an array of objects receives primitive elements instead" do
+    invalid_payload = {
+      "name"    => "Acme Corp",
+      "billing" => {"plan" => "pro"},
+      "tags"    => ["tech"],
+      "members" => [
+        "this-should-be-an-object",
+      ],
+    }
+
+    res = nested_client.post("/orgs", body: invalid_payload.to_json)
+
+    res.status.should eq(422)
+    res.json["details"]["members[0]"].as_s.should eq("must be an object")
+  end
+
+  it "catches when a hash field receives a non-object" do
+    invalid_payload = {
+      "name"    => "Acme Corp",
+      "billing" => "I should be a hash",
+      "tags"    => ["tech"],
+      "members" => [] of String,
+    }
+
+    res = nested_client.post("/orgs", body: invalid_payload.to_json)
+
+    res.status.should eq(422)
+    res.json["details"]["billing"].as_s.should eq("must be an object")
+  end
+end

--- a/spec/rule/orchestrator_spec.cr
+++ b/spec/rule/orchestrator_spec.cr
@@ -169,6 +169,19 @@ describe Alumna::Orchestrator do
       ctx.result_set?.should be_true
       ctx.result.as(Hash(String, Alumna::AnyData))["cached"].should eq(true)
     end
+
+    it "short-circuits even if the result is explicitly set to nil" do
+      rule = Alumna::Rule.new do |ctx|
+        ctx.result = nil
+        nil.as(Alumna::ServiceError?)
+      end
+      ctx = Alumna::Testing.build_ctx(phase: Alumna::RulePhase::Before)
+
+      Alumna::Orchestrator.run([rule], ctx, short_circuit: true)
+
+      ctx.result_set?.should be_true
+      ctx.result.should be_nil
+    end
   end
 
   describe "early exit does not apply in After phase" do

--- a/spec/rule/orchestrator_spec.cr
+++ b/spec/rule/orchestrator_spec.cr
@@ -22,6 +22,22 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 
 describe Alumna::Orchestrator do
+  describe ".run with start parameter" do
+    it "starts execution from the given index" do
+      log = [] of String
+      rules = [
+        continuing_rule(log, "a"),
+        continuing_rule(log, "b"),
+        continuing_rule(log, "c"),
+      ]
+
+      result = Alumna::Orchestrator.run(rules, Alumna::Testing.build_ctx, start: 1)
+
+      result.should be_true
+      log.should eq(["b", "c"])
+    end
+  end
+
   describe ".run with empty rule list" do
     it "returns true and leaves context unchanged" do
       ctx = Alumna::Testing.build_ctx

--- a/spec/schema/validator_spec.cr
+++ b/spec/schema/validator_spec.cr
@@ -270,4 +270,64 @@ describe Alumna::Schema do
       errors_for(schema, empty_data, Alumna::ServiceMethod::Patch).should be_empty
     end
   end
+
+  describe "Nested Fields" do
+    it "validates a nested hash object" do
+      schema = Alumna::Schema.new.hash("profile") do |s|
+        s.str("username", min_length: 3)
+        s.int("age")
+      end
+
+      # Valid
+      valid_data = {"profile" => {"username" => any("Alice"), "age" => any(30)} of String => Alumna::AnyData}
+      errors_for(schema, valid_data).should be_empty
+
+      # Invalid nested fields
+      invalid_data = {"profile" => {"username" => any("Al"), "age" => any("old")} of String => Alumna::AnyData}
+      errs = errors_for(schema, invalid_data)
+
+      errs.find { |e| e.field == "profile.username" }.try(&.message).should eq("must be at least 3 characters")
+      errs.find { |e| e.field == "profile.age" }.try(&.message).should eq("must be an integer")
+    end
+
+    it "validates an array of primitives" do
+      schema = Alumna::Schema.new.array("tags", of: :str, min_length: 1, max_length: 3)
+
+      # Valid array size & type
+      errors_for(schema, {"tags" => [any("crystal"), any("alumna")] of Alumna::AnyData}).should be_empty
+
+      # Invalid element type
+      errs = errors_for(schema, {"tags" => [any("crystal"), any(123)] of Alumna::AnyData})
+      errs.first.field.should eq("tags[1]")
+      errs.first.message.should eq("must be a string")
+
+      # Invalid array constraints (min_length applied to array size!)
+      errs_len = errors_for(schema, {"tags" => [] of Alumna::AnyData})
+      errs_len.first.field.should eq("tags")
+      errs_len.first.message.should eq("must contain at least 1 item")
+    end
+
+    it "validates an array of objects" do
+      schema = Alumna::Schema.new.array("users") do |s|
+        s.str("id")
+        s.bool("admin")
+      end
+
+      valid_data = {"users" => [
+        {"id" => any("u1"), "admin" => any(true)} of String => Alumna::AnyData,
+        {"id" => any("u2"), "admin" => any(false)} of String => Alumna::AnyData,
+      ] of Alumna::AnyData}
+
+      errors_for(schema, valid_data).should be_empty
+
+      invalid_data = {"users" => [
+        {"id" => any("u1"), "admin" => any("yes")} of String => Alumna::AnyData,
+        any("not-an-object"),
+      ] of Alumna::AnyData}
+
+      errs = errors_for(schema, invalid_data)
+      errs.find { |e| e.field == "users[0].admin" }.try(&.message).should eq("must be true or false")
+      errs.find { |e| e.field == "users[1]" }.try(&.message).should eq("must be an object")
+    end
+  end
 end

--- a/spec/service/base_spec.cr
+++ b/spec/service/base_spec.cr
@@ -6,27 +6,27 @@ private class ExplodingService < Alumna::Service
     super()
   end
 
-  def find(ctx) : Array(Hash(String, Alumna::AnyData))
+  def find(ctx) : Array(Hash(String, Alumna::AnyData)) | Alumna::ServiceError
     raise "kaboom"
   end
 
-  def get(ctx) : Hash(String, Alumna::AnyData)?
+  def get(ctx) : Hash(String, Alumna::AnyData)? | Alumna::ServiceError
     raise Exception.new
   end
 
-  def create(ctx) : Hash(String, Alumna::AnyData)
+  def create(ctx) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     {} of String => Alumna::AnyData
   end
 
-  def update(ctx) : Hash(String, Alumna::AnyData)
+  def update(ctx) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     {} of String => Alumna::AnyData
   end
 
-  def patch(ctx) : Hash(String, Alumna::AnyData)
+  def patch(ctx) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     {} of String => Alumna::AnyData
   end
 
-  def remove(ctx) : Bool
+  def remove(ctx) : Bool | Alumna::ServiceError
     true
   end
 end

--- a/spec/service/context_spec.cr
+++ b/spec/service/context_spec.cr
@@ -2,6 +2,27 @@ require "../spec_helper"
 require "../../src/testing"
 
 describe Alumna::RuleContext do
+  describe "result handling" do
+    it "is not set initially" do
+      ctx = Alumna::Testing.build_ctx
+      ctx.result_set?.should be_false
+      ctx.result.should be_nil
+    end
+
+    it "is set when explicitly assigned nil" do
+      ctx = Alumna::Testing.build_ctx
+      ctx.result = nil
+      ctx.result_set?.should be_true
+      ctx.result.should be_nil
+    end
+
+    it "is set when assigned a Hash" do
+      ctx = Alumna::Testing.build_ctx
+      ctx.result = {"ok" => true} of String => Alumna::AnyData
+      ctx.result_set?.should be_true
+    end
+  end
+
   describe "typed data accessors" do
     it "returns String for data_str?" do
       ctx = Alumna::Testing.build_ctx(data: {"name" => "Alice"} of String => Alumna::AnyData)

--- a/spec/service/dispatch_spec.cr
+++ b/spec/service/dispatch_spec.cr
@@ -9,17 +9,17 @@ private class TrackedService < Alumna::MemoryAdapter
     @called = [] of String
   end
 
-  def find(ctx : Alumna::RuleContext) : Array(Hash(String, Alumna::AnyData))
+  def find(ctx : Alumna::RuleContext) : Array(Hash(String, Alumna::AnyData)) | Alumna::ServiceError
     @called << "find"
     super
   end
 
-  def create(ctx : Alumna::RuleContext) : Hash(String, Alumna::AnyData)
+  def create(ctx : Alumna::RuleContext) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     @called << "create"
     super
   end
 
-  def update(ctx : Alumna::RuleContext) : Hash(String, Alumna::AnyData)
+  def update(ctx : Alumna::RuleContext) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     @called << "update"
     super
   end

--- a/spec/service/dispatch_spec.cr
+++ b/spec/service/dispatch_spec.cr
@@ -248,6 +248,16 @@ describe "Dispatch" do
       service.called.should be_empty
     end
 
+    it "short-circuits even if the result is explicitly set to nil" do
+      service = TrackedService.new
+      service.before(Alumna::Rule.new do |ctx|
+        ctx.result = nil
+        nil.as(Alumna::ServiceError?)
+      end)
+      dispatch(service, Alumna::ServiceMethod::Find)
+      service.called.should be_empty
+    end
+
     it "run after rules even with result already set" do
       log = [] of String
       service = TrackedService.new

--- a/spec/service/error_spec.cr
+++ b/spec/service/error_spec.cr
@@ -14,22 +14,6 @@ describe Alumna::ServiceError do
       err.status.should eq(400)
       err.details.empty?.should be_true
     end
-
-    it "is an Exception" do
-      err = Alumna::ServiceError.new("x")
-      (err.is_a?(Exception)).should be_true
-    end
-
-    it "can be raised and rescued" do
-      rescued = false
-      begin
-        raise Alumna::ServiceError.new("test", 400)
-      rescue ex : Alumna::ServiceError
-        rescued = true
-        ex.message.should eq("test")
-      end
-      rescued.should be_true
-    end
   end
 
   describe ".bad_request" do

--- a/spec/service/query_spec.cr
+++ b/spec/service/query_spec.cr
@@ -5,7 +5,8 @@ describe Alumna::Query do
     params = HTTP::Params.parse("name=Bob&$limit=2&$skip=1&$sort=age:-1&$select=id,name")
     q = Alumna::Query.new(Alumna::Http::ParamsView.new(params))
 
-    q.filters["name"].should eq("Bob")
+    q.filters["name"].first.value.should eq("Bob")
+    q.filters["name"].first.op.should eq(Alumna::Query::Op::Eq)
     q.limit.should eq(2)
     q.skip.should eq(1)
     q.sort.should eq([{"age", -1}])
@@ -15,7 +16,7 @@ describe Alumna::Query do
   it "ignores unknown $ keys" do
     params = HTTP::Params.parse("$foo=bar&x=1")
     q = Alumna::Query.new(Alumna::Http::ParamsView.new(params))
-    q.filters["x"].should eq("1")
+    q.filters["x"].first.value.should eq("1")
     q.filters.has_key?("$foo").should be_false
   end
 
@@ -25,5 +26,24 @@ describe Alumna::Query do
 
     q2 = Alumna::Query.new(Alumna::Http::ParamsView.new(HTTP::Params.parse("x=1")))
     q2.empty?.should be_false
+  end
+
+  it "parses filter operators" do
+    params = HTTP::Params.parse("age[$gt]=18&age[$lt]=30&status[$in]=active,pending&category[name]=tech")
+    q = Alumna::Query.new(Alumna::Http::ParamsView.new(params))
+
+    q.filters["age"].size.should eq(2)
+    q.filters["age"][0].op.should eq(Alumna::Query::Op::Gt)
+    q.filters["age"][0].value.should eq("18")
+    q.filters["age"][1].op.should eq(Alumna::Query::Op::Lt)
+    q.filters["age"][1].value.should eq("30")
+
+    q.filters["status"].size.should eq(1)
+    q.filters["status"][0].op.should eq(Alumna::Query::Op::In)
+    q.filters["status"][0].value.should eq(["active", "pending"])
+
+    q.filters["category[name]"].size.should eq(1)
+    q.filters["category[name]"][0].op.should eq(Alumna::Query::Op::Eq)
+    q.filters["category[name]"][0].value.should eq("tech")
   end
 end

--- a/spec/testing/app_client_spec.cr
+++ b/spec/testing/app_client_spec.cr
@@ -2,23 +2,23 @@ require "../spec_helper"
 require "../../src/testing"
 
 class EchoService < Alumna::MemoryAdapter
-  def find(ctx)
+  def find(ctx) : Array(Hash(String, Alumna::AnyData)) | Alumna::ServiceError
     [{"echo" => ctx.http_method} of String => Alumna::AnyData]
   end
 
-  def create(ctx)
+  def create(ctx) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     {"echo" => ctx.http_method, "body" => ctx.data["msg"]?} of String => Alumna::AnyData
   end
 
-  def update(ctx)
+  def update(ctx) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     {"echo" => ctx.http_method} of String => Alumna::AnyData
   end
 
-  def patch(ctx)
+  def patch(ctx) : Hash(String, Alumna::AnyData) | Alumna::ServiceError
     {"echo" => ctx.http_method} of String => Alumna::AnyData
   end
 
-  def remove(ctx)
+  def remove(ctx) : Bool | Alumna::ServiceError
     true
   end
 end

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -123,7 +123,7 @@ module Alumna
       end
     end
 
-    def find(ctx : RuleContext) : Array(Hash(String, AnyData))
+    def find(ctx : RuleContext) : Array(Hash(String, AnyData)) | ServiceError
       @mutex.synchronize do
         q = ctx.query
         records = @store.values
@@ -171,7 +171,7 @@ module Alumna
       end
     end
 
-    def get(ctx : RuleContext) : Hash(String, AnyData)?
+    def get(ctx : RuleContext) : Hash(String, AnyData)? | ServiceError
       @mutex.synchronize do
         id = ctx.id
         return nil if id.nil?
@@ -179,7 +179,7 @@ module Alumna
       end
     end
 
-    def create(ctx : RuleContext) : Hash(String, AnyData)
+    def create(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
       @mutex.synchronize do
         id = @next_id.to_s
         @next_id += 1
@@ -190,10 +190,12 @@ module Alumna
       end
     end
 
-    def update(ctx : RuleContext) : Hash(String, AnyData)
+    def update(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
       @mutex.synchronize do
-        id = ctx.id || raise ServiceError.bad_request("ID required for update")
-        raise ServiceError.not_found unless @store.has_key?(id)
+        id = ctx.id
+        return ServiceError.bad_request("ID required for update") unless id
+        return ServiceError.not_found unless @store.has_key?(id)
+
         record = ctx.data.dup
         record["id"] = id
         @store[id] = record
@@ -201,10 +203,14 @@ module Alumna
       end
     end
 
-    def patch(ctx : RuleContext) : Hash(String, AnyData)
+    def patch(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
       @mutex.synchronize do
-        id = ctx.id || raise ServiceError.bad_request("ID required for patch")
-        existing = @store[id]? || raise ServiceError.not_found
+        id = ctx.id
+        return ServiceError.bad_request("ID required for patch") unless id
+
+        existing = @store[id]?
+        return ServiceError.not_found unless existing
+
         record = existing.merge(ctx.data)
         record["id"] = id
         @store[id] = record
@@ -212,9 +218,10 @@ module Alumna
       end
     end
 
-    def remove(ctx : RuleContext) : Bool
+    def remove(ctx : RuleContext) : Bool | ServiceError
       @mutex.synchronize do
-        id = ctx.id || raise ServiceError.bad_request("ID required for remove")
+        id = ctx.id
+        return ServiceError.bad_request("ID required for remove") unless id
         !@store.delete(id).nil?
       end
     end

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -158,7 +158,9 @@ module Alumna
 
         # 4) select
         if fields = q.select
+          # LCOV_EXCL_START - kcov wrongly misses.map
           records.map do |rec|
+            # LCOV_EXCL_STOP
             selected = rec.select(fields)
             selected["id"] = rec["id"] if rec["id"]? && !selected.has_key?("id")
             selected

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -1,3 +1,6 @@
+# ================================================
+# FILE: src/adapter/memory.cr
+# ================================================
 module Alumna
   class MemoryAdapter < Service
     @store : Hash(String, Hash(String, AnyData))
@@ -12,19 +15,14 @@ module Alumna
     end
 
     private def compare_values(a : AnyData, b : AnyData) : Int32
-      # Handle nil / missing fields (nils come first)
       return 0 if a.nil? && b.nil?
       return -1 if a.nil?
       return 1 if b.nil?
 
-      # Safely compare numbers by arithmetic value (Int64 and Float64)
       if (a.is_a?(Int64) || a.is_a?(Float64)) && (b.is_a?(Int64) || b.is_a?(Float64))
-        # Float64#<=> returns Int32? (returns nil when comparing with NaN)
-        # We fallback to 0 (equal) to satisfy the strict Int32 return requirement.
         return (a.as(Int64 | Float64) <=> b.as(Int64 | Float64)) || 0
       end
 
-      # Compare identical string or boolean types
       if a.class == b.class
         case a
         when String
@@ -34,8 +32,98 @@ module Alumna
         end
       end
 
-      # Deterministic fallback for mismatched types or complex structures
       a.to_s <=> b.to_s
+    end
+
+    private def extract_value(rec : Hash(String, AnyData), field : String) : AnyData
+      # Fast path for standard top-level fields
+      return rec[field] if rec.has_key?(field)
+
+      # Fallback to dot notation for nested fields
+      current : AnyData = rec
+      field.split('.').each do |part|
+        if current.is_a?(Hash(String, AnyData))
+          if current.has_key?(part)
+            current = current[part]
+          else
+            return nil
+          end
+        else
+          return nil
+        end
+      end
+      current
+    end
+
+    private def match_condition?(val : AnyData, cond : Query::Condition) : Bool
+      # Distributor arrays natively. e.g. `$ne` requires ALL elements to not match.
+      if val.is_a?(Array(AnyData))
+        if cond.op.ne? || cond.op.nin?
+          val.all? { |v| match_single_value?(v, cond) }
+        else
+          val.any? { |v| match_single_value?(v, cond) }
+        end
+      else
+        match_single_value?(val, cond)
+      end
+    end
+
+    private def match_single_value?(val : AnyData, cond : Query::Condition) : Bool
+      str_val = val.try(&.to_s)
+
+      case cond.op
+      when .eq?
+        str_val == cond.value
+      when .ne?
+        str_val != cond.value
+      when .in?
+        cv = cond.value
+        cv.is_a?(Array) ? cv.includes?(str_val) : false
+      when .nin?
+        cv = cond.value
+        cv.is_a?(Array) ? !cv.includes?(str_val) : true
+      else
+        cv = cond.value
+        return false unless cv.is_a?(String)
+
+        cmp = compare_query_value(val, cv)
+        return false unless cmp
+
+        case cond.op
+        when .gt?  then cmp > 0
+        when .gte? then cmp >= 0
+        when .lt?  then cmp < 0
+        when .lte? then cmp <= 0
+        else            false
+        end
+      end
+    end
+
+    private def compare_query_value(record_val : AnyData, query_val : String) : Int32?
+      return nil if record_val.nil?
+
+      case record_val
+      when Int64
+        if q_int = query_val.to_i64?
+          record_val <=> q_int
+        else
+          nil
+        end
+      when Float64
+        if q_float = query_val.to_f64?
+          record_val <=> q_float
+        else
+          nil
+        end
+      when Bool
+        q_bool = query_val == "true" ? true : (query_val == "false" ? false : nil)
+        return nil if q_bool.nil?
+        (record_val ? 1 : 0) <=> (q_bool ? 1 : 0)
+      when String
+        record_val <=> query_val
+      else
+        nil
+      end
     end
 
     def find(ctx : RuleContext) : Array(Hash(String, AnyData))
@@ -43,10 +131,15 @@ module Alumna
         q = ctx.query
         records = @store.values
 
-        # 1) filters (old behaviour, now via q.filters)
+        # 1) filters
         unless q.filters.empty?
           records = records.select do |rec|
-            q.filters.all? { |k, v| rec[k]?.try(&.to_s) == v }
+            q.filters.all? do |field, conditions|
+              val = extract_value(rec, field)
+              conditions.all? do |cond|
+                match_condition?(val, cond)
+              end
+            end
           end
         end
 
@@ -55,7 +148,7 @@ module Alumna
           records.sort! do |a, b|
             sort.reduce(0) do |cmp, (field, dir)|
               next cmp if cmp != 0
-              compare_values(a[field]?, b[field]?) * dir
+              compare_values(extract_value(a, field), extract_value(b, field)) * dir
             end
           end
         end
@@ -66,11 +159,9 @@ module Alumna
           records = records.first(limit)
         end
 
-        # 4) select (always keep id for sanity)
+        # 4) select
         if fields = q.select
-          # LCOV_EXCL_START - kcov wrongly misses.map
           records.map do |rec|
-            # LCOV_EXCL_STOP
             selected = rec.select(fields)
             selected["id"] = rec["id"] if rec["id"]? && !selected.has_key?("id")
             selected

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -11,6 +11,33 @@ module Alumna
       @mutex = Mutex.new
     end
 
+    private def compare_values(a : AnyData, b : AnyData) : Int32
+      # Handle nil / missing fields (nils come first)
+      return 0 if a.nil? && b.nil?
+      return -1 if a.nil?
+      return 1 if b.nil?
+
+      # Safely compare numbers by arithmetic value (Int64 and Float64)
+      if (a.is_a?(Int64) || a.is_a?(Float64)) && (b.is_a?(Int64) || b.is_a?(Float64))
+        # Float64#<=> returns Int32? (returns nil when comparing with NaN)
+        # We fallback to 0 (equal) to satisfy the strict Int32 return requirement.
+        return (a.as(Int64 | Float64) <=> b.as(Int64 | Float64)) || 0
+      end
+
+      # Compare identical string or boolean types
+      if a.class == b.class
+        case a
+        when String
+          return a <=> b.as(String)
+        when Bool
+          return (a ? 1 : 0) <=> (b.as(Bool) ? 1 : 0)
+        end
+      end
+
+      # Deterministic fallback for mismatched types or complex structures
+      a.to_s <=> b.to_s
+    end
+
     def find(ctx : RuleContext) : Array(Hash(String, AnyData))
       @mutex.synchronize do
         q = ctx.query
@@ -28,9 +55,7 @@ module Alumna
           records.sort! do |a, b|
             sort.reduce(0) do |cmp, (field, dir)|
               next cmp if cmp != 0
-              av = a[field]?.try(&.to_s) || ""
-              bv = b[field]?.try(&.to_s) || ""
-              (av <=> bv) * dir
+              compare_values(a[field]?, b[field]?) * dir
             end
           end
         end

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -2,13 +2,13 @@ module Alumna
   class MemoryAdapter < Service
     @store : Hash(String, Hash(String, AnyData))
     @next_id : Int64
-    @mutex : Mutex
+    @mutex : Sync::Mutex
 
     def initialize(schema : Schema? = nil)
       super(schema)
       @store = {} of String => Hash(String, AnyData)
       @next_id = 1_i64
-      @mutex = Mutex.new
+      @mutex = Sync::Mutex.new
     end
 
     private def compare_values(a : AnyData, b : AnyData) : Int32

--- a/src/adapter/memory.cr
+++ b/src/adapter/memory.cr
@@ -1,6 +1,3 @@
-# ================================================
-# FILE: src/adapter/memory.cr
-# ================================================
 module Alumna
   class MemoryAdapter < Service
     @store : Hash(String, Hash(String, AnyData))

--- a/src/app.cr
+++ b/src/app.cr
@@ -41,12 +41,16 @@ module Alumna
           svc_a = service.collect_rules(m, RulePhase::After)
           app_a = collect_rules(m, RulePhase::After)
           service.set_after_pipeline(m, svc_a, app_a)
+
+          svc_e = service.collect_rules(m, RulePhase::Error)
+          app_e = collect_rules(m, RulePhase::Error)
+          service.set_error_pipeline(m, svc_e, app_e)
         end
       end
       @pipelines_compiled = true
     end
 
-    # Central dispatch using merged pipelines (2 Orchestrator calls)
+    # Central dispatch using merged pipelines
     def dispatch(service : Service, ctx : RuleContext) : RuleContext
       compile_pipelines! unless @pipelines_compiled
       m = ctx.method
@@ -59,8 +63,8 @@ module Alumna
       unless ok
         ctx.phase = RulePhase::Error
         # run service error only if stop happened in service part
-        Orchestrator.run(service.collect_rules(m, RulePhase::Error), ctx) unless stopped_in_app
-        Orchestrator.run(collect_rules(m, RulePhase::Error), ctx)
+        start_idx = stopped_in_app ? service.error_svc_len(m) : 0
+        Orchestrator.run(service.error_pipeline(m), ctx, start: start_idx)
         return ctx
       end
 
@@ -71,8 +75,7 @@ module Alumna
         if error
           ctx.error = error
           ctx.phase = RulePhase::Error
-          Orchestrator.run(service.collect_rules(m, RulePhase::Error), ctx)
-          Orchestrator.run(collect_rules(m, RulePhase::Error), ctx)
+          Orchestrator.run(service.error_pipeline(m), ctx)
           return ctx
         end
         ctx.result = result
@@ -83,8 +86,7 @@ module Alumna
       after_rules = service.after_pipeline(m)
       unless Orchestrator.run(after_rules, ctx)
         ctx.phase = RulePhase::Error
-        Orchestrator.run(service.collect_rules(m, RulePhase::Error), ctx)
-        Orchestrator.run(collect_rules(m, RulePhase::Error), ctx)
+        Orchestrator.run(service.error_pipeline(m), ctx)
       end
       ctx
     end

--- a/src/app.cr
+++ b/src/app.cr
@@ -11,9 +11,13 @@ module Alumna
 
     property max_body_size : Int64 = 1_048_576
 
+    @pipeline_mutex : Sync::Mutex
+    @pipelines_compiled : Atomic(Bool)
+
     def initialize(@serializer : Http::Serializer = Http::JsonSerializer.new)
       @services = {} of String => Service
-      @pipelines_compiled = false
+      @pipelines_compiled = Atomic(Bool).new(false)
+      @pipeline_mutex = Sync::Mutex.new
     end
 
     def use(path : String, service : Service) : self
@@ -30,29 +34,40 @@ module Alumna
     end
 
     private def compile_pipelines!
-      return if @pipelines_compiled
-      @services.each_value do |service|
-        # Compile merged pipelines once
-        ServiceMethod.values.each do |m|
-          app_b = collect_rules(m, RulePhase::Before)
-          svc_b = service.collect_rules(m, RulePhase::Before)
-          service.set_before_pipeline(m, app_b, svc_b)
+      # Outer fast path: :acquire pairs with the :release write below,
+      # ensuring all pipeline writes are visible once we see true.
+      return if @pipelines_compiled.get(:acquire)
 
-          svc_a = service.collect_rules(m, RulePhase::After)
-          app_a = collect_rules(m, RulePhase::After)
-          service.set_after_pipeline(m, svc_a, app_a)
+      @pipeline_mutex.synchronize do
+        # Inner check: the mutex lock already carries :acquire semantics,
+        # so :relaxed is sufficient here.
+        return if @pipelines_compiled.get(:relaxed)
 
-          svc_e = service.collect_rules(m, RulePhase::Error)
-          app_e = collect_rules(m, RulePhase::Error)
-          service.set_error_pipeline(m, svc_e, app_e)
+        @services.each_value do |service|
+          # Compile merged pipelines once
+          ServiceMethod.values.each do |m|
+            app_b = collect_rules(m, RulePhase::Before)
+            svc_b = service.collect_rules(m, RulePhase::Before)
+            service.set_before_pipeline(m, app_b, svc_b)
+
+            svc_a = service.collect_rules(m, RulePhase::After)
+            app_a = collect_rules(m, RulePhase::After)
+            service.set_after_pipeline(m, svc_a, app_a)
+
+            svc_e = service.collect_rules(m, RulePhase::Error)
+            app_e = collect_rules(m, RulePhase::Error)
+            service.set_error_pipeline(m, svc_e, app_e)
+          end
         end
+        # :release ensures all pipeline writes above are visible to any
+        # thread that subsequently reads with :acquire.
+        @pipelines_compiled.set(true, :release)
       end
-      @pipelines_compiled = true
     end
 
     # Central dispatch using merged pipelines
     def dispatch(service : Service, ctx : RuleContext) : RuleContext
-      compile_pipelines! unless @pipelines_compiled
+      compile_pipelines! unless @pipelines_compiled.get(:acquire)
       m = ctx.method
 
       # 1. BEFORE (app + service)
@@ -91,15 +106,35 @@ module Alumna
       ctx
     end
 
-    def listen(port : Int32 = 3000, *, host : String = "127.0.0.1", trusted_proxies : TrustedProxies = nil)
+    def listen(
+      port : Int32 = 3000,
+      *,
+      host : String = "127.0.0.1",
+      trusted_proxies : TrustedProxies = nil,
+      workers : Int32? = nil,
+    )
       compile_pipelines! # freeze once, after all rules are registered
+
+      workers_msg = ""
+      {% if flag?(:execution_context) %}
+        actual_workers = workers || Fiber::ExecutionContext.default_workers_count
+        Fiber::ExecutionContext.default.resize(actual_workers.clamp(1..))
+        workers_msg = " (#{actual_workers} workers)"
+      {% else %}
+        if workers && workers > 1
+          STDERR.puts "Warning: 'workers' argument ignored. To enable multithreading, compile with: -Dpreview_mt -Dexecution_context"
+        end
+        workers_msg = " (single-threaded)"
+      {% end %}
 
       router = Http::Router.new(self, trusted_proxies)
       server = HTTP::Server.new { |ctx| router.handle(ctx) }
-      server.bind_tcp(host, port, reuse_port: false)
+
+      # reuse_port is no longer needed since Crystal threads share the same socket
+      server.bind_tcp(host, port)
 
       display_host = host.includes?(':') ? "[#{host}]" : host
-      puts "Listening on http://#{display_host}:#{port}"
+      puts "Listening on http://#{display_host}:#{port}#{workers_msg}"
 
       if host == "0.0.0.0" || host == "::"
         STDERR.puts "Warning: binding to #{host} exposes the server on all interfaces"

--- a/src/app.cr
+++ b/src/app.cr
@@ -173,10 +173,10 @@ module Alumna
         STDERR.puts "Warning: binding to #{host} exposes the server on all interfaces"
       end
 
+      # LCOV_EXCL_START - kcov wrongly misses this block
       begin
-        # LCOV_EXCL_START - kcov wrongly misses this block
-        server.listen # Blocks until server.close is called, or an error occurs
         # LCOV_EXCL_STOP
+        server.listen # Blocks until server.close is called, or an error occurs
       ensure
         if trap_signals
           Signal::INT.reset

--- a/src/app.cr
+++ b/src/app.cr
@@ -8,16 +8,24 @@ module Alumna
 
     getter serializer : Http::Serializer
     getter services : Hash(String, Service)
+    getter active_requests : Atomic(Int32)
 
     property max_body_size : Int64 = 1_048_576
 
     @pipeline_mutex : Sync::Mutex
     @pipelines_compiled : Atomic(Bool)
+    @server : HTTP::Server?
 
     def initialize(@serializer : Http::Serializer = Http::JsonSerializer.new)
       @services = {} of String => Service
       @pipelines_compiled = Atomic(Bool).new(false)
       @pipeline_mutex = Sync::Mutex.new
+      @active_requests = Atomic(Int32).new(0)
+      @server = nil
+    end
+
+    def close : Nil
+      @server.try(&.close)
     end
 
     def use(path : String, service : Service) : self
@@ -112,6 +120,8 @@ module Alumna
       host : String = "127.0.0.1",
       trusted_proxies : TrustedProxies = nil,
       workers : Int32? = nil,
+      shutdown_timeout : Time::Span? = 10.seconds,
+      trap_signals : Bool = true,
     )
       compile_pipelines! # freeze once, after all rules are registered
 
@@ -128,7 +138,30 @@ module Alumna
       {% end %}
 
       router = Http::Router.new(self, trusted_proxies)
-      server = HTTP::Server.new { |ctx| router.handle(ctx) }
+
+      # We wrap the router handle in a counter to track active connections
+      server = HTTP::Server.new do |ctx|
+        @active_requests.add(1)
+        begin
+          router.handle(ctx)
+        ensure
+          @active_requests.sub(1)
+        end
+      end
+      @server = server
+
+      if trap_signals
+        trap_handler = ->(sig : Signal) do
+          puts "\nReceived #{sig}, shutting down gracefully..."
+          # Reset traps so a second Ctrl+C forces an immediate, ungraceful exit if desired
+          Signal::INT.reset
+          Signal::TERM.reset
+          close
+        end
+
+        Signal::INT.trap { trap_handler.call(Signal::INT) }
+        Signal::TERM.trap { trap_handler.call(Signal::TERM) }
+      end
 
       # reuse_port is no longer needed since Crystal threads share the same socket
       server.bind_tcp(host, port)
@@ -140,7 +173,29 @@ module Alumna
         STDERR.puts "Warning: binding to #{host} exposes the server on all interfaces"
       end
 
-      server.listen
+      begin
+        server.listen # Blocks until server.close is called, or an error occurs
+      ensure
+        if trap_signals
+          Signal::INT.reset
+          Signal::TERM.reset
+        end
+
+        if timeout = shutdown_timeout
+          deadline = Time.instant + timeout
+
+          # Wait loop blocking the process from exiting as long as we have active requests
+          while @active_requests.get > 0 && Time.instant < deadline
+            sleep 0.05.seconds
+          end
+
+          if (rem = @active_requests.get) > 0
+            puts "Shutdown timeout reached. Exiting with #{rem} active requests."
+          else
+            puts "Graceful shutdown complete."
+          end
+        end
+      end
     end
   end
 end

--- a/src/app.cr
+++ b/src/app.cr
@@ -174,7 +174,9 @@ module Alumna
       end
 
       begin
+        # LCOV_EXCL_START - kcov wrongly misses this block
         server.listen # Blocks until server.close is called, or an error occurs
+        # LCOV_EXCL_STOP
       ensure
         if trap_signals
           Signal::INT.reset

--- a/src/http/router.cr
+++ b/src/http/router.cr
@@ -33,10 +33,9 @@ module Alumna
         output_serializer = resolve_output_serializer(request) || input_serializer
         response.content_type = output_serializer.content_type
 
-        begin
-          data = parse_body(request, input_serializer)
-        rescue ex : ServiceError
-          Responder.write_error(response, ex, output_serializer)
+        data = parse_body(request, input_serializer)
+        if data.is_a?(ServiceError)
+          Responder.write_error(response, data, output_serializer)
           return
         end
 
@@ -64,7 +63,7 @@ module Alumna
           params: ParamsView.new(request.query_params),
           headers: HeadersView.new(request.headers),
           id: id,
-          data: data
+          data: data # Flow-typing knows this is a Hash(String, AnyData) here
         )
 
         ctx.app.dispatch(service, ctx)
@@ -121,7 +120,7 @@ module Alumna
         Serializers.from_accept?(request.headers["accept"]?)
       end
 
-      private def parse_body(request : HTTP::Request, serializer : Serializer) : Hash(String, AnyData)
+      private def parse_body(request : HTTP::Request, serializer : Serializer) : Hash(String, AnyData) | ServiceError
         body = request.body
         return {} of String => AnyData if body.nil?
 
@@ -132,14 +131,14 @@ module Alumna
 
         if limit = @app.max_body_size
           if (len = request.content_length) && len > limit
-            raise ServiceError.new("Payload Too Large", 413)
+            return ServiceError.new("Payload Too Large", 413)
           end
           body = LimitedIO.new(body, limit)
         end
 
         serializer.decode(body)
       rescue IO::Error
-        raise ServiceError.new("Payload Too Large", 413)
+        ServiceError.new("Payload Too Large", 413)
       end
 
       private def remote_ip(ctx : HTTP::Server::Context) : String

--- a/src/http/serializer.cr
+++ b/src/http/serializer.cr
@@ -4,7 +4,7 @@ module Alumna
       abstract def content_type : String
       abstract def encode(data : Hash(String, AnyData), io : IO) : Nil
       abstract def encode(data : Array(Hash(String, AnyData)), io : IO) : Nil
-      abstract def decode(io : IO) : Hash(String, AnyData)
+      abstract def decode(io : IO) : Hash(String, AnyData) | ServiceError
     end
   end
 end

--- a/src/http/serializers/json_serializer.cr
+++ b/src/http/serializers/json_serializer.cr
@@ -15,17 +15,17 @@ module Alumna
         data.to_json(io)
       end
 
-      def decode(io : IO) : Hash(String, AnyData)
+      def decode(io : IO) : Hash(String, AnyData) | ServiceError
         parsed = JSON.parse(io)
         result = convert(parsed)
 
         unless result.is_a?(Hash)
-          raise ServiceError.new("Request body must be a JSON object", 400)
+          return ServiceError.new("Request body must be a JSON object", 400)
         end
 
         result.as(Hash(String, AnyData))
       rescue JSON::ParseException
-        raise ServiceError.new("Malformed JSON", 400)
+        ServiceError.new("Malformed JSON", 400)
       end
 
       private def convert(value : JSON::Any) : AnyData

--- a/src/http/serializers/msgpack_serializer.cr
+++ b/src/http/serializers/msgpack_serializer.cr
@@ -15,7 +15,7 @@ module Alumna
         data.to_msgpack(io)
       end
 
-      def decode(io : IO) : Hash(String, AnyData)
+      def decode(io : IO) : Hash(String, AnyData) | ServiceError
         unpacker = MessagePack::IOUnpacker.new(io)
         result = {} of String => AnyData
         unpacker.consume_table do |key|
@@ -23,7 +23,7 @@ module Alumna
         end
         result
       rescue MessagePack::UnpackError | MessagePack::TypeCastError | MessagePack::EofError
-        raise ServiceError.new("Malformed MessagePack", 400)
+        ServiceError.new("Malformed MessagePack", 400)
       end
 
       private def normalize(value : MessagePack::Type) : AnyData

--- a/src/rule/builtin/rate_limiter.cr
+++ b/src/rule/builtin/rate_limiter.cr
@@ -13,7 +13,7 @@ require "mutex"
 #    - Each entry stores both a wall-clock `reset_at` (for HTTP headers) and a
 #      monotonic `deadline` (Time::Instant).
 #    - Once `deadline` passes, the entry is useless. It is removed by an
-#      amortized sweep that runs every 1,024 hits inside the same Mutex.
+#      amortized sweep that runs every 1,024 hits inside the same Sync::Mutex.
 #    - No background fiber, no timers, no hidden state. Memory usage is
 #      proportional to keys seen in the last window, not total history.
 #
@@ -29,7 +29,7 @@ require "mutex"
 #    - The same interface can later back a `RateLimitRedisStore` without
 #      touching the Rule API.
 #
-# Hot path remains O(1): one Hash lookup under a Mutex. Cleanup is O(N) but
+# Hot path remains O(1): one Hash lookup under a Sync::Mutex. Cleanup is O(N) but
 # amortized and infrequent, keeping throughput comparable to Go/Rust
 # implementations while staying fully explicit.
 
@@ -42,7 +42,7 @@ module Alumna
 
     def initialize(@window : Time::Span, @cleanup_every : Int32 = 1024)
       @store = Hash(String, Entry).new
-      @mutex = Mutex.new
+      @mutex = Sync::Mutex.new
       @ops = 0
     end
 

--- a/src/rule/orchestrator.cr
+++ b/src/rule/orchestrator.cr
@@ -1,7 +1,7 @@
 module Alumna
   module Orchestrator
-    def self.run(rules : Array(Rule), ctx : RuleContext, short_circuit = false) : Bool
-      i = 0
+    def self.run(rules : Array(Rule), ctx : RuleContext, short_circuit = false, *, start : Int32 = 0) : Bool
+      i = start
       size = rules.size
       while i < size
         if err = rules.unsafe_fetch(i).call(ctx)

--- a/src/schema/base.cr
+++ b/src/schema/base.cr
@@ -9,6 +9,8 @@ module Alumna
     getter format_name : String?
     getter format_validator : Proc(String, Bool)?
     getter format_message : String?
+    getter sub_schema : Schema?
+    getter element_type : FieldType?
 
     def initialize(
       @name : String,
@@ -20,12 +22,14 @@ module Alumna
       @format_validator : Proc(String, Bool)? = nil,
       @format_message : String? = nil,
       @required_on : Array(ServiceMethod)? = nil,
+      @sub_schema : Schema? = nil,
+      @element_type : FieldType? = nil,
     )
     end
   end
 
   enum FieldType
-    Str; Int; Float; Bool; Nullable
+    Str; Int; Float; Bool; Nullable; Hash; Array
   end
 
   class Schema
@@ -35,7 +39,6 @@ module Alumna
       @fields = [] of FieldDescriptor
     end
 
-    # Core API - accepts Symbols for ergonomics
     def field(
       name : String,
       type : FieldType | Symbol,
@@ -44,11 +47,11 @@ module Alumna
       max_length : Int32? = nil,
       format : Symbol | String | Nil = nil,
       required_on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil,
+      sub_schema : Schema? = nil,
+      element_type : FieldType? = nil,
     ) : self
-      # normalize :str → FieldType::Str
       field_type = type.is_a?(Symbol) ? FieldType.parse(type.to_s.capitalize) : type
 
-      # normalize format to downcased string, resolve validator once
       format_name = nil
       format_validator = nil
       format_message = nil
@@ -69,7 +72,6 @@ module Alumna
         end
       end
 
-      # normalize :create → [ServiceMethod::Create], also accepts single symbol
       norm_required_on = case required_on
                          in Nil
                            nil
@@ -93,11 +95,13 @@ module Alumna
         format_validator: format_validator,
         format_message: format_message,
         required_on: norm_required_on,
+        sub_schema: sub_schema,
+        element_type: element_type
       )
       self
     end
 
-    # --- tiny helpers for readability ---
+    # --- Standard helpers ---
     def str(name, **opts)
       field(name, :str, **opts)
     end
@@ -118,7 +122,28 @@ module Alumna
       field(name, :nullable, **opts)
     end
 
-    # optional block-style builder
+    # --- Nested helpers ---
+
+    # For objects/hashes
+    def hash(name : String, **opts, &block : Schema ->)
+      sub = Schema.new
+      yield sub
+      field(name, :hash, **opts, sub_schema: sub)
+    end
+
+    # For arrays of primitives
+    def array(name : String, of : FieldType | Symbol, **opts)
+      el_type = of.is_a?(Symbol) ? FieldType.parse(of.to_s.capitalize) : of
+      field(name, :array, **opts, element_type: el_type.as(FieldType))
+    end
+
+    # For arrays of objects
+    def array(name : String, **opts, &block : Schema ->)
+      sub = Schema.new
+      yield sub
+      field(name, :array, **opts, sub_schema: sub)
+    end
+
     def self.build(& : self ->) : self
       schema = new
       yield schema

--- a/src/schema/validator.cr
+++ b/src/schema/validator.cr
@@ -8,63 +8,99 @@ module Alumna
   end
 
   class Schema
-    # Shared sentinel returned when validation passes.
-    # Treat as read-only - never mutate the result of validate directly.
     EMPTY_ERRORS = [] of FieldError
 
     def validate(data : Hash(String, AnyData), method : ServiceMethod? = nil) : Array(FieldError)
       errors = nil
+      # A single tracker instantiated once per validation to trace paths without allocations
+      path = [] of String | Int32
+      errors = _validate(data, method, path, errors)
+      errors || EMPTY_ERRORS
+    end
 
+    protected def _validate(data : Hash(String, AnyData), method : ServiceMethod?, path : Array(String | Int32), errors : Array(FieldError)?) : Array(FieldError)?
       @fields.each do |field|
+        path.push(field.name)
         has_key = data.has_key?(field.name)
         value = data[field.name]?
 
         # --- Presence check ---
         unless has_key
-          errors = push_error(errors, field.name, "is required") if required?(field, method)
+          errors = push_error(errors, path, "is required") if required?(field, method)
+          path.pop
           next
         end
 
         # --- Explicit null ---
         if value.nil?
-          next if field.type.nullable?
-          errors = push_error(errors, field.name, "is required") if required?(field, method)
+          unless field.type.nullable?
+            errors = push_error(errors, path, "is required") if required?(field, method)
+          end
+          path.pop
           next
         end
 
         # --- Type check ---
-        if type_error = check_type(field, value)
-          errors = push_error(errors, field.name, type_error)
+        if type_error = check_type(field.type, value)
+          errors = push_error(errors, path, type_error)
+          path.pop
           next
         end
 
-        # --- Constraint checks (only for strings) ---
-        if field.type.str? && value.is_a?(String)
-          str = value
+        # --- Length Constraints (Shared for String & Array) ---
+        if (field.type.str? && value.is_a?(String)) || (field.type.array? && value.is_a?(Array(AnyData)))
           if min = field.min_length
-            if str.size < min
-              errors = push_error(errors, field.name, "must be at least #{min} character#{min == 1 ? "" : "s"}")
+            if value.size < min
+              msg = field.type.array? ? "must contain at least #{min} item#{min == 1 ? "" : "s"}" : "must be at least #{min} character#{min == 1 ? "" : "s"}"
+              errors = push_error(errors, path, msg)
             end
           end
           if max = field.max_length
-            if str.size > max
-              errors = push_error(errors, field.name, "must be at most #{max} character#{max == 1 ? "" : "s"}")
-            end
-          end
-          if validator = field.format_validator
-            unless validator.call(str)
-              errors = push_error(errors, field.name, field.format_message || "has an invalid format")
+            if value.size > max
+              msg = field.type.array? ? "must contain at most #{max} item#{max == 1 ? "" : "s"}" : "must be at most #{max} character#{max == 1 ? "" : "s"}"
+              errors = push_error(errors, path, msg)
             end
           end
         end
+
+        # --- String-only Formats ---
+        if field.type.str? && value.is_a?(String)
+          if validator = field.format_validator
+            unless validator.call(value)
+              errors = push_error(errors, path, field.format_message || "has an invalid format")
+            end
+          end
+        end
+
+        # --- Nested Traversal ---
+        if field.type.hash? && value.is_a?(Hash(String, AnyData))
+          if sub = field.sub_schema
+            errors = sub._validate(value, method, path, errors)
+          end
+        elsif field.type.array? && value.is_a?(Array(AnyData))
+          value.each_with_index do |item, idx|
+            path.push(idx)
+            if sub = field.sub_schema
+              if item.is_a?(Hash(String, AnyData))
+                errors = sub._validate(item, method, path, errors)
+              else
+                errors = push_error(errors, path, "must be an object")
+              end
+            elsif el_type = field.element_type
+              if type_err = check_type(el_type, item)
+                errors = push_error(errors, path, type_err)
+              end
+            end
+            path.pop
+          end
+        end
+
+        path.pop
       end
 
-      errors || EMPTY_ERRORS
+      errors
     end
 
-    # Returns true if the field is required for the given method context.
-    # Extracted to eliminate the identical logic that appeared in both the
-    # presence check and the explicit-null check.
     private def required?(field : FieldDescriptor, method : ServiceMethod?) : Bool
       if req_on = field.required_on
         method.nil? || req_on.includes?(method)
@@ -73,21 +109,34 @@ module Alumna
       end
     end
 
-    # Lazily allocates the errors array on the first error, then reuses it.
-    # Returns the (possibly newly created) array with the new entry appended.
     @[AlwaysInline]
-    private def push_error(errors : Array(FieldError)?, field : String, message : String) : Array(FieldError)
+    private def push_error(errors : Array(FieldError)?, path : Array(String | Int32), message : String) : Array(FieldError)
       arr = errors || [] of FieldError
-      arr << FieldError.new(field, message)
+
+      # Generates a string like "user.address.coordinates[0]" natively
+      field_path = String.build do |io|
+        path.each_with_index do |part, i|
+          if part.is_a?(Int32)
+            io << "[" << part << "]"
+          else
+            io << "." if i > 0
+            io << part
+          end
+        end
+      end
+
+      arr << FieldError.new(field_path, message)
       arr
     end
 
-    private def check_type(field : FieldDescriptor, value : AnyData) : String?
-      case field.type
+    private def check_type(type : FieldType, value : AnyData) : String?
+      case type
       when .str?   then value.is_a?(String) ? nil : "must be a string"
       when .int?   then value.is_a?(Int64) ? nil : "must be an integer"
       when .float? then (value.is_a?(Float64) || value.is_a?(Int64)) ? nil : "must be a number"
       when .bool?  then value.is_a?(Bool) ? nil : "must be true or false"
+      when .hash?  then value.is_a?(Hash(String, AnyData)) ? nil : "must be an object"
+      when .array? then value.is_a?(Array(AnyData)) ? nil : "must be an array"
       else              nil
       end
     end

--- a/src/service/base.cr
+++ b/src/service/base.cr
@@ -31,12 +31,12 @@ module Alumna
 
     # -----------------------------
 
-    abstract def find(ctx : RuleContext) : Array(Hash(String, AnyData))
-    abstract def get(ctx : RuleContext) : Hash(String, AnyData)?
-    abstract def create(ctx : RuleContext) : Hash(String, AnyData)
-    abstract def update(ctx : RuleContext) : Hash(String, AnyData)
-    abstract def patch(ctx : RuleContext) : Hash(String, AnyData)
-    abstract def remove(ctx : RuleContext) : Bool
+    abstract def find(ctx : RuleContext) : Array(Hash(String, AnyData)) | ServiceError
+    abstract def get(ctx : RuleContext) : Hash(String, AnyData)? | ServiceError
+    abstract def create(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
+    abstract def update(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
+    abstract def patch(ctx : RuleContext) : Hash(String, AnyData) | ServiceError
+    abstract def remove(ctx : RuleContext) : Bool | ServiceError
 
     def set_before_pipeline(method : ServiceMethod, app_rules : Array(Rule), svc_rules : Array(Rule))
       idx = method.value
@@ -75,25 +75,29 @@ module Alumna
     end
 
     protected def call_method(ctx : RuleContext) : {ServiceResult, ServiceError?}
-      case ctx.method
-      when .find? then {find(ctx), nil}
-      when .get?
-        result = get(ctx)
-        raise ServiceError.not_found unless result
-        {result, nil}
-      when .create? then {create(ctx), nil}
-      when .update? then {update(ctx), nil}
-      when .patch?  then {patch(ctx), nil}
-      when .remove?
-        removed = {"removed" => remove(ctx)} of String => AnyData
-        {removed, nil}
-      when .options? then { {} of String => AnyData, nil }
+      result = case ctx.method
+               when .find?    then find(ctx)
+               when .get?     then get(ctx)
+               when .create?  then create(ctx)
+               when .update?  then update(ctx)
+               when .patch?   then patch(ctx)
+               when .remove?  then remove(ctx)
+               when .options? then {} of String => AnyData
+               else
+                 return {nil, ServiceError.internal("Unknown service method")}
+               end
+
+      if result.is_a?(ServiceError)
+        {nil, result}
+      elsif ctx.method.get? && result.nil?
+        {nil, ServiceError.not_found}
+      elsif ctx.method.remove? && result.is_a?(Bool)
+        { {"removed" => result} of String => AnyData, nil }
       else
-        {nil, ServiceError.internal("Unknown service method")}
+        {result.as(ServiceResult), nil}
       end
-    rescue ex : ServiceError
-      {nil, ex}
     rescue ex : Exception
+      # Catching raw Exception acts as a safety net for DB connection drops, math faults, etc.
       {nil, ServiceError.internal(ex.message || "Unexpected error")}
     end
   end

--- a/src/service/base.cr
+++ b/src/service/base.cr
@@ -8,20 +8,21 @@ module Alumna
     # Merged pipelines built by App.use
     @before_pipeline : Array(Array(Rule))
     @after_pipeline : Array(Array(Rule))
+    @error_pipeline : Array(Array(Rule))
     @before_app_len : Array(Int32)
+    @error_svc_len : Array(Int32)
 
     def initialize(@schema : Schema? = nil)
       size = ServiceMethod.values.size
       @before_pipeline = Array.new(size) { [] of Rule }
       @after_pipeline = Array.new(size) { [] of Rule }
+      @error_pipeline = Array.new(size) { [] of Rule }
       @before_app_len = Array.new(size, 0)
+      @error_svc_len = Array.new(size, 0)
     end
 
     # ---- convenience helpers ----
 
-    # Returns a validation Rule for this service's schema.
-    # Use inside a service block: `before validate, on: :write`
-    # You can override with `validate(other_schema)` if needed.
     def validate(schema : Schema? = nil) : Rule
       s = schema || self.schema
       raise ArgumentError.new("validate requires a schema - service has none and none was passed") unless s
@@ -47,6 +48,12 @@ module Alumna
       @after_pipeline[method.value] = svc_rules + app_rules
     end
 
+    def set_error_pipeline(method : ServiceMethod, svc_rules : Array(Rule), app_rules : Array(Rule))
+      idx = method.value
+      @error_pipeline[idx] = svc_rules + app_rules
+      @error_svc_len[idx] = svc_rules.size
+    end
+
     def before_pipeline(method) : Array(Rule)
       @before_pipeline[method.value]
     end
@@ -55,8 +62,16 @@ module Alumna
       @after_pipeline[method.value]
     end
 
+    def error_pipeline(method) : Array(Rule)
+      @error_pipeline[method.value]
+    end
+
     def before_app_len(method) : Int32
       @before_app_len[method.value]
+    end
+
+    def error_svc_len(method) : Int32
+      @error_svc_len[method.value]
     end
 
     protected def call_method(ctx : RuleContext) : {ServiceResult, ServiceError?}

--- a/src/service/context.cr
+++ b/src/service/context.cr
@@ -2,7 +2,6 @@ require "json"
 require "http"
 
 module Alumna
-  # forward declarations - full bodies live in http/router.cr
   module Http
     struct ParamsView; end
 
@@ -72,7 +71,6 @@ module Alumna
       @result_set
     end
 
-    # ---- typed data accessors (zero-cost, inlined) ----
     def data_str?(key) : String?
       data[key]?.as?(String)
     end
@@ -110,14 +108,33 @@ module Alumna
   end
 
   class Query
-    getter filters : Hash(String, String)
+    enum Op
+      Eq
+      Ne
+      Gt
+      Gte
+      Lt
+      Lte
+      In
+      Nin
+    end
+
+    struct Condition
+      getter op : Op
+      getter value : String | Array(String)
+
+      def initialize(@op : Op, @value : String | Array(String))
+      end
+    end
+
+    getter filters : Hash(String, Array(Condition))
     getter limit : Int32?
     getter skip : Int32?
     getter sort : Array(Tuple(String, Int32))?
     getter select : Array(String)?
 
     def initialize(params : Http::ParamsView)
-      @filters = {} of String => String
+      @filters = Hash(String, Array(Condition)).new { |h, k| h[k] = [] of Condition }
       @limit = nil
       @skip = nil
       @sort = nil
@@ -130,7 +147,6 @@ module Alumna
         when "$skip"
           @skip = parse_positive_int v
         when "$sort"
-          # "age:-1,name:1" → [{"age",-1},{"name",1}]
           @sort = v.split(',').compact_map do |part|
             field, dir = part.split(':', 2)
             next if field.empty?
@@ -140,7 +156,28 @@ module Alumna
         when "$select"
           @select = v.split(',').map(&.strip).reject(&.empty?)
         else
-          @filters[k] = v unless k.starts_with?('$')
+          next if k.starts_with?('$')
+
+          field = k
+          op_str = "$eq"
+
+          if k.ends_with?(']') && (bracket_idx = k.index('['))
+            field = k[0...bracket_idx]
+            op_str = k[bracket_idx + 1...-1]
+          end
+
+          op = parse_op(op_str)
+          if op.nil?
+            field = k
+            op = Op::Eq
+          end
+
+          if op.in? || op.nin?
+            val = v.split(',')
+            @filters[field] << Condition.new(op, val)
+          else
+            @filters[field] << Condition.new(op, v)
+          end
         end
       end
     end
@@ -149,10 +186,24 @@ module Alumna
       @filters.empty? && @limit.nil? && @skip.nil? && @sort.nil? && @select.nil?
     end
 
+    private def parse_op(s : String) : Op?
+      case s
+      when "$eq"  then Op::Eq
+      when "$ne"  then Op::Ne
+      when "$gt"  then Op::Gt
+      when "$gte" then Op::Gte
+      when "$lt"  then Op::Lt
+      when "$lte" then Op::Lte
+      when "$in"  then Op::In
+      when "$nin" then Op::Nin
+      else             nil
+      end
+    end
+
     @[AlwaysInline]
     private def parse_positive_int(str : String) : Int32?
       return nil if str.empty?
-      str.each_byte { |b| return nil unless 48 <= b <= 57 } # '0'..'9'
+      str.each_byte { |b| return nil unless 48 <= b <= 57 }
       str.to_i?
     end
   end

--- a/src/service/context.cr
+++ b/src/service/context.cr
@@ -29,6 +29,7 @@ module Alumna
     property http : HttpOverrides
     property headers : Http::HeadersView
 
+    @result_set : Bool = false
     @store : Hash(String, AnyData)?
     @query : Query?
 
@@ -57,12 +58,18 @@ module Alumna
       @data : Hash(String, AnyData) = {} of String => AnyData,
     )
       @result = nil
+      @result_set = false
       @error = nil
       @http = HttpOverrides.new
     end
 
+    def result=(value : ServiceResult)
+      @result = value
+      @result_set = true
+    end
+
     def result_set? : Bool
-      !@result.nil?
+      @result_set
     end
 
     # ---- typed data accessors (zero-cost, inlined) ----

--- a/src/service/error.cr
+++ b/src/service/error.cr
@@ -1,11 +1,11 @@
 module Alumna
-  class ServiceError < Exception
+  struct ServiceError
     getter status : Int32
     getter details : Hash(String, AnyData)
+    getter message : String
 
-    def initialize(message : String, @status : Int32 = 400, details : Hash(String, AnyData) = {} of String => AnyData)
-      @details = details
-      super(message)
+    def initialize(@message : String, @status : Int32 = 400, details : Hash(String, AnyData)? = nil)
+      @details = details || {} of String => AnyData
     end
 
     def self.bad_request(message : String, details = {} of String => AnyData)

--- a/src/testing/adapter_suite.cr
+++ b/src/testing/adapter_suite.cr
@@ -150,6 +150,37 @@ module Alumna
               results.map(&.["name"]).should eq(["B", "A"])
             end
 
+            it "applies $sort correctly with string types" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"str" => Alumna::Testing::AdapterSuiteHelpers.any("banana")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"str" => Alumna::Testing::AdapterSuiteHelpers.any("apple")} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "str:1"})
+              adapter.find(ctx).map(&.["str"]).should eq(["apple", "banana"])
+            end
+
+            it "applies $sort correctly with boolean types" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"flag" => Alumna::Testing::AdapterSuiteHelpers.any(true)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"flag" => Alumna::Testing::AdapterSuiteHelpers.any(false)} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "flag:1"})
+              # false is 0, true is 1. So false comes before true.
+              adapter.find(ctx).map(&.["flag"]).should eq([false, true])
+            end
+
+            it "applies $sort using string fallback for mismatched types or complex structures" do
+              adapter = {{factory.body}}
+              # Insert a string, an integer, and an array to trigger the fallback
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => Alumna::Testing::AdapterSuiteHelpers.any("10")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => Alumna::Testing::AdapterSuiteHelpers.any(2)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => [Alumna::Testing::AdapterSuiteHelpers.any(1)] of Alumna::AnyData} of String => Alumna::AnyData)
+
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "mixed:1"})
+
+              # Fallback uses to_s: "10", "2", and "[1]"
+              # Lexicographically: "10" < "2" < "[1]"
+              adapter.find(ctx).map(&.["mixed"]).should eq(["10", 2_i64, [1_i64] of Alumna::AnyData])
+            end
+
             it "applies $select" do
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"a" => Alumna::Testing::AdapterSuiteHelpers.any("1"), "b" => Alumna::Testing::AdapterSuiteHelpers.any("2")} of String => Alumna::AnyData)

--- a/src/testing/adapter_suite.cr
+++ b/src/testing/adapter_suite.cr
@@ -2,7 +2,6 @@ require "spec"
 
 module Alumna
   module Testing
-    # Helper methods used internally by the AdapterSuite to avoid polluting the spec namespace
     module AdapterSuiteHelpers
       def self.any(v : String) : AnyData
         v
@@ -31,8 +30,6 @@ module Alumna
     end
 
     module AdapterSuite
-      # A macro that injects the universal behavioral tests for any Alumna::Service adapter.
-      # It accepts a string name and a block that initializes and returns a fresh instance of the adapter.
       macro run(name, &factory)
         describe {{name}} do
           describe "#create" do
@@ -69,7 +66,7 @@ module Alumna
             end
           end
 
-          describe "#find" do
+          describe "#find (filtering)" do
             it "returns an empty array when the store is empty" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find)
@@ -113,6 +110,103 @@ module Alumna
               adapter.find(ctx).should be_empty
             end
 
+            it "filters records using $ne operator" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("admin")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("user")} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"role[$ne]" => "admin"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["role"].should eq("user")
+            end
+
+            it "filters records using $gt and $lt operators" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(10)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(20)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"age[$gt]" => "15", "age[$lt]" => "25"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["age"].should eq(20)
+            end
+
+            it "filters strings using $gt operator lexicographically" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"letter" => Alumna::Testing::AdapterSuiteHelpers.any("a")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"letter" => Alumna::Testing::AdapterSuiteHelpers.any("b")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"letter" => Alumna::Testing::AdapterSuiteHelpers.any("c")} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"letter[$gt]" => "a", "letter[$lt]" => "c"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["letter"].should eq("b")
+            end
+
+            it "filters records using $gte and $lte operators" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(10)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(20)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"age[$gte]" => "20", "age[$lte]" => "30"})
+              results = adapter.find(ctx)
+              results.size.should eq(2)
+              results.map(&.["age"]).should eq([20_i64, 30_i64])
+            end
+
+            it "filters records using $in operator" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("pending")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("active")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("archived")} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"status[$in]" => "pending,active"})
+              results = adapter.find(ctx)
+              results.size.should eq(2)
+              results.map(&.["status"]).should eq(["pending", "active"])
+            end
+
+            it "filters records using $nin operator" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("pending")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("active")} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("archived")} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"status[$nin]" => "pending,active"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["status"].should eq("archived")
+            end
+
+            it "filters records by nested fields using dot notation" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice"), "age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Bob"), "age" => Alumna::Testing::AdapterSuiteHelpers.any(40)} of String => Alumna::AnyData} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"user.name" => "Bob"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["user"].as(Hash(String, Alumna::AnyData))["name"].should eq("Bob")
+            end
+
+            it "filters array fields where an element matches the condition" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("tech"), Alumna::Testing::AdapterSuiteHelpers.any("science")] of Alumna::AnyData} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("art")] of Alumna::AnyData} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"tags" => "tech"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["tags"].as(Array(Alumna::AnyData)).first.should eq("tech")
+            end
+
+            it "filters array fields where no element matches $ne" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("tech"), Alumna::Testing::AdapterSuiteHelpers.any("science")] of Alumna::AnyData} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("art")] of Alumna::AnyData} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"tags[$ne]" => "tech"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["tags"].as(Array(Alumna::AnyData)).first.should eq("art")
+            end
+          end
+
+          describe "#find (sorting and limit/skip)" do
             it "applies $limit and $skip" do
               adapter = {{factory.body}}
               5.times { |i| Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"n" => Alumna::Testing::AdapterSuiteHelpers.any(i.to_s)} of String => Alumna::AnyData) }
@@ -143,10 +237,9 @@ module Alumna
             it "handles missing values in $sort gracefully" do
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("A"), "pos" => Alumna::Testing::AdapterSuiteHelpers.any(2)} of String => Alumna::AnyData)
-              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("B")} of String => Alumna::AnyData) # Missing pos
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("B")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "pos:1"})
               results = adapter.find(ctx)
-              # Missing fields are evaluated as nil, so B should come before A
               results.map(&.["name"]).should eq(["B", "A"])
             end
 
@@ -163,22 +256,26 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"flag" => Alumna::Testing::AdapterSuiteHelpers.any(true)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"flag" => Alumna::Testing::AdapterSuiteHelpers.any(false)} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "flag:1"})
-              # false is 0, true is 1. So false comes before true.
               adapter.find(ctx).map(&.["flag"]).should eq([false, true])
             end
 
             it "applies $sort using string fallback for mismatched types or complex structures" do
               adapter = {{factory.body}}
-              # Insert a string, an integer, and an array to trigger the fallback
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => Alumna::Testing::AdapterSuiteHelpers.any("10")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => Alumna::Testing::AdapterSuiteHelpers.any(2)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => [Alumna::Testing::AdapterSuiteHelpers.any(1)] of Alumna::AnyData} of String => Alumna::AnyData)
-
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "mixed:1"})
-
-              # Fallback uses to_s: "10", "2", and "[1]"
-              # Lexicographically: "10" < "2" < "[1]"
               adapter.find(ctx).map(&.["mixed"]).should eq(["10", 2_i64, [1_i64] of Alumna::AnyData])
+            end
+
+            it "sorts records by nested fields using dot notation" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"age" => Alumna::Testing::AdapterSuiteHelpers.any(40)} of String => Alumna::AnyData} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "user.age:1"})
+              results = adapter.find(ctx)
+              results.size.should eq(2)
+              results.first["user"].as(Hash(String, Alumna::AnyData))["age"].should eq(30)
             end
 
             it "applies $select" do
@@ -188,7 +285,7 @@ module Alumna
               rec = adapter.find(ctx).first
               rec.has_key?("a").should be_true
               rec.has_key?("b").should be_false
-              rec.has_key?("id").should be_true # id always preserved
+              rec.has_key?("id").should be_true
             end
 
             it "applies $select when id is explicitly requested" do

--- a/src/testing/adapter_suite.cr
+++ b/src/testing/adapter_suite.cr
@@ -25,7 +25,7 @@ module Alumna
           method: ServiceMethod::Create,
           data: data
         )
-        adapter.create(ctx)
+        adapter.create(ctx).as(Hash(String, AnyData))
       end
     end
 
@@ -36,7 +36,7 @@ module Alumna
             it "returns the record with an auto-assigned id" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Create, data: {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice")} of String => Alumna::AnyData)
-              record = adapter.create(ctx)
+              record = adapter.create(ctx).as(Hash(String, Alumna::AnyData))
               record["id"].should eq("1")
               record["name"].should eq("Alice")
             end
@@ -52,7 +52,7 @@ module Alumna
             it "overrides any id supplied in the input data with its own counter" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Create, data: {"id" => Alumna::Testing::AdapterSuiteHelpers.any("999"), "name" => Alumna::Testing::AdapterSuiteHelpers.any("Bob")} of String => Alumna::AnyData)
-              record = adapter.create(ctx)
+              record = adapter.create(ctx).as(Hash(String, Alumna::AnyData))
               record["id"].should eq("1")
             end
 
@@ -60,9 +60,8 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice")} of String => Alumna::AnyData)
               get_ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Get, id: "1")
-              record = adapter.get(get_ctx)
-              record.should_not be_nil
-              record.try(&.["name"]).should eq("Alice")
+              record = adapter.get(get_ctx).as(Hash(String, Alumna::AnyData))
+              record["name"].should eq("Alice")
             end
           end
 
@@ -70,7 +69,7 @@ module Alumna
             it "returns an empty array when the store is empty" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find)
-              adapter.find(ctx).should be_empty
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).should be_empty
             end
 
             it "returns all records when no params are given" do
@@ -78,7 +77,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Bob")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find)
-              adapter.find(ctx).size.should eq(2)
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).size.should eq(2)
             end
 
             it "filters records by a single query param" do
@@ -86,7 +85,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("admin")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("user")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"role" => "admin"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["role"].should eq("admin")
             end
@@ -97,7 +96,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("admin"), "active" => Alumna::Testing::AdapterSuiteHelpers.any(false)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("user"), "active" => Alumna::Testing::AdapterSuiteHelpers.any(true)} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"role" => "admin", "active" => "true"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["role"].should eq("admin")
               results.first["active"].should eq(true)
@@ -107,7 +106,7 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("user")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"role" => "admin"})
-              adapter.find(ctx).should be_empty
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).should be_empty
             end
 
             it "filters records using $ne operator" do
@@ -115,7 +114,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("admin")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"role" => Alumna::Testing::AdapterSuiteHelpers.any("user")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"role[$ne]" => "admin"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["role"].should eq("user")
             end
@@ -127,13 +126,12 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData)
 
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"age[$gt]" => "15", "age[$lt]" => "25"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["age"].should eq(20)
 
-              # Test invalid integer parsing gracefully falling back
               ctx2 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"age[$gt]" => "abc"})
-              adapter.find(ctx2).should be_empty
+              adapter.find(ctx2).as(Array(Hash(String, Alumna::AnyData))).should be_empty
             end
 
             it "filters records using $gt and $lt operators on Float64" do
@@ -143,13 +141,12 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"rating" => Alumna::Testing::AdapterSuiteHelpers.any(5.0)} of String => Alumna::AnyData)
 
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"rating[$gt]" => "4.0", "rating[$lt]" => "4.9"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["rating"].should eq(4.5)
 
-              # Test invalid float parsing gracefully falling back
               ctx2 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"rating[$gt]" => "abc"})
-              adapter.find(ctx2).should be_empty
+              adapter.find(ctx2).as(Array(Hash(String, Alumna::AnyData))).should be_empty
             end
 
             it "filters records using $gt and $lt operators on Bool" do
@@ -157,21 +154,18 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"active" => Alumna::Testing::AdapterSuiteHelpers.any(true)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"active" => Alumna::Testing::AdapterSuiteHelpers.any(false)} of String => Alumna::AnyData)
 
-              # true (1) > false (0)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"active[$gt]" => "false"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["active"].should eq(true)
 
-              # false (0) < true (1)
               ctx2 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"active[$lt]" => "true"})
-              results2 = adapter.find(ctx2)
+              results2 = adapter.find(ctx2).as(Array(Hash(String, Alumna::AnyData)))
               results2.size.should eq(1)
               results2.first["active"].should eq(false)
 
-              # Test invalid bool parsing gracefully falling back
               ctx3 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"active[$gt]" => "not-a-bool"})
-              adapter.find(ctx3).should be_empty
+              adapter.find(ctx3).as(Array(Hash(String, Alumna::AnyData))).should be_empty
             end
 
             it "filters strings using $gt operator lexicographically" do
@@ -180,7 +174,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"letter" => Alumna::Testing::AdapterSuiteHelpers.any("b")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"letter" => Alumna::Testing::AdapterSuiteHelpers.any("c")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"letter[$gt]" => "a", "letter[$lt]" => "c"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["letter"].should eq("b")
             end
@@ -191,7 +185,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(20)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"age[$gte]" => "20", "age[$lte]" => "30"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(2)
               results.map(&.["age"]).should eq([20_i64, 30_i64])
             end
@@ -202,7 +196,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("active")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("archived")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"status[$in]" => "pending,active"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(2)
               results.map(&.["status"]).should eq(["pending", "active"])
             end
@@ -213,7 +207,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("active")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"status" => Alumna::Testing::AdapterSuiteHelpers.any("archived")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"status[$nin]" => "pending,active"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["status"].should eq("archived")
             end
@@ -223,7 +217,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice"), "age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Bob"), "age" => Alumna::Testing::AdapterSuiteHelpers.any(40)} of String => Alumna::AnyData} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"user.name" => "Bob"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["user"].as(Hash(String, Alumna::AnyData))["name"].should eq("Bob")
             end
@@ -233,7 +227,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("tech"), Alumna::Testing::AdapterSuiteHelpers.any("science")] of Alumna::AnyData} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("art")] of Alumna::AnyData} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"tags" => "tech"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["tags"].as(Array(Alumna::AnyData)).first.should eq("tech")
             end
@@ -243,7 +237,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("tech"), Alumna::Testing::AdapterSuiteHelpers.any("science")] of Alumna::AnyData} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"tags" => [Alumna::Testing::AdapterSuiteHelpers.any("art")] of Alumna::AnyData} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"tags[$ne]" => "tech"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(1)
               results.first["tags"].as(Array(Alumna::AnyData)).first.should eq("art")
             end
@@ -254,7 +248,7 @@ module Alumna
               adapter = {{factory.body}}
               5.times { |i| Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"n" => Alumna::Testing::AdapterSuiteHelpers.any(i.to_s)} of String => Alumna::AnyData) }
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$skip" => "1", "$limit" => "2"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(2)
               results.map(&.["n"]).should eq(["1", "2"])
             end
@@ -265,7 +259,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"score" => Alumna::Testing::AdapterSuiteHelpers.any(9)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"score" => Alumna::Testing::AdapterSuiteHelpers.any(25)} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "score:1"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.map(&.["score"]).should eq([9_i64, 25_i64, 100_i64])
             end
 
@@ -274,7 +268,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"val" => Alumna::Testing::AdapterSuiteHelpers.any(10)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"val" => Alumna::Testing::AdapterSuiteHelpers.any(9.5)} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "val:1"})
-              adapter.find(ctx).map(&.["val"]).should eq([9.5_f64, 10_i64])
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).map(&.["val"]).should eq([9.5_f64, 10_i64])
             end
 
             it "handles missing values in $sort gracefully" do
@@ -282,7 +276,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("A"), "pos" => Alumna::Testing::AdapterSuiteHelpers.any(2)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("B")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "pos:1"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.map(&.["name"]).should eq(["B", "A"])
             end
 
@@ -291,7 +285,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"str" => Alumna::Testing::AdapterSuiteHelpers.any("banana")} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"str" => Alumna::Testing::AdapterSuiteHelpers.any("apple")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "str:1"})
-              adapter.find(ctx).map(&.["str"]).should eq(["apple", "banana"])
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).map(&.["str"]).should eq(["apple", "banana"])
             end
 
             it "applies $sort correctly with boolean types" do
@@ -299,7 +293,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"flag" => Alumna::Testing::AdapterSuiteHelpers.any(true)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"flag" => Alumna::Testing::AdapterSuiteHelpers.any(false)} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "flag:1"})
-              adapter.find(ctx).map(&.["flag"]).should eq([false, true])
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).map(&.["flag"]).should eq([false, true])
             end
 
             it "applies $sort using string fallback for mismatched types or complex structures" do
@@ -308,7 +302,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => Alumna::Testing::AdapterSuiteHelpers.any(2)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"mixed" => [Alumna::Testing::AdapterSuiteHelpers.any(1)] of Alumna::AnyData} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "mixed:1"})
-              adapter.find(ctx).map(&.["mixed"]).should eq(["10", 2_i64, [1_i64] of Alumna::AnyData])
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).map(&.["mixed"]).should eq(["10", 2_i64, [1_i64] of Alumna::AnyData])
             end
 
             it "sorts records by nested fields using dot notation" do
@@ -316,7 +310,7 @@ module Alumna
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"age" => Alumna::Testing::AdapterSuiteHelpers.any(40)} of String => Alumna::AnyData} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"user" => {"age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "user.age:1"})
-              results = adapter.find(ctx)
+              results = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
               results.size.should eq(2)
               results.first["user"].as(Hash(String, Alumna::AnyData))["age"].should eq(30)
             end
@@ -325,7 +319,7 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"a" => Alumna::Testing::AdapterSuiteHelpers.any("1"), "b" => Alumna::Testing::AdapterSuiteHelpers.any("2")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$select" => "a"})
-              rec = adapter.find(ctx).first
+              rec = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).first
               rec.has_key?("a").should be_true
               rec.has_key?("b").should be_false
               rec.has_key?("id").should be_true
@@ -335,14 +329,14 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"a" => Alumna::Testing::AdapterSuiteHelpers.any("1"), "b" => Alumna::Testing::AdapterSuiteHelpers.any("2")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$select" => "a,id"})
-              rec = adapter.find(ctx).first
+              rec = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).first
               rec.keys.sort!.should eq(["a", "id"])
             end
 
             it "applies $select on empty store" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$select" => "a"})
-              adapter.find(ctx).should be_empty
+              adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).should be_empty
             end
           end
 
@@ -351,9 +345,8 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Get, id: "1")
-              record = adapter.get(ctx)
-              record.should_not be_nil
-              record.try(&.["name"]).should eq("Alice")
+              record = adapter.get(ctx).as(Hash(String, Alumna::AnyData))
+              record["name"].should eq("Alice")
             end
 
             it "returns nil for an unknown id" do
@@ -374,7 +367,7 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice"), "role" => Alumna::Testing::AdapterSuiteHelpers.any("user")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Update, id: "1", data: {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice"), "role" => Alumna::Testing::AdapterSuiteHelpers.any("admin")} of String => Alumna::AnyData)
-              record = adapter.update(ctx)
+              record = adapter.update(ctx).as(Hash(String, Alumna::AnyData))
               record["id"].should eq("1")
               record["role"].should eq("admin")
             end
@@ -385,7 +378,7 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice"), "role" => Alumna::Testing::AdapterSuiteHelpers.any("user")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Patch, id: "1", data: {"role" => Alumna::Testing::AdapterSuiteHelpers.any("admin")} of String => Alumna::AnyData)
-              record = adapter.patch(ctx)
+              record = adapter.patch(ctx).as(Hash(String, Alumna::AnyData))
               record["name"].should eq("Alice")
               record["role"].should eq("admin")
               record["id"].should eq("1")
@@ -398,26 +391,25 @@ module Alumna
               adapter.patch(patch_ctx)
 
               get_ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Get, id: "1")
-              record = adapter.get(get_ctx)
-              record.should_not be_nil
-              if record
-                record["name"].should eq("Alice")
-                record["role"].should eq("admin")
-              end
+              record = adapter.get(get_ctx).as(Hash(String, Alumna::AnyData))
+              record["name"].should eq("Alice")
+              record["role"].should eq("admin")
             end
 
-            it "raises a 404 error when the id does not exist" do
+            it "returns a 404 error when the id does not exist" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Patch, id: "99", data: {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Ghost")} of String => Alumna::AnyData)
-              error = expect_raises(Alumna::ServiceError) { adapter.patch(ctx) }
-              error.status.should eq(404)
+              result = adapter.patch(ctx)
+              result.should be_a(Alumna::ServiceError)
+              result.as(Alumna::ServiceError).status.should eq(404)
             end
 
-            it "raises a 400 error when ctx.id is nil" do
+            it "returns a 400 error when ctx.id is nil" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Patch, id: nil, data: {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Ghost")} of String => Alumna::AnyData)
-              error = expect_raises(Alumna::ServiceError) { adapter.patch(ctx) }
-              error.status.should eq(400)
+              result = adapter.patch(ctx)
+              result.should be_a(Alumna::ServiceError)
+              result.as(Alumna::ServiceError).status.should eq(400)
             end
           end
 
@@ -426,7 +418,7 @@ module Alumna
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("Alice")} of String => Alumna::AnyData)
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Remove, id: "1")
-              adapter.remove(ctx).should be_true
+              adapter.remove(ctx).as(Bool).should be_true
             end
 
             it "makes the record unretrievable after deletion" do
@@ -442,14 +434,20 @@ module Alumna
             it "returns false when the id does not exist" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Remove, id: "99")
-              adapter.remove(ctx).should be_false
+              result = adapter.remove(ctx)
+              if result.is_a?(Bool)
+                result.should be_false
+              elsif result.is_a?(Alumna::ServiceError)
+                result.status.should eq(404)
+              end
             end
 
-            it "raises a 400 error when ctx.id is nil" do
+            it "returns a 400 error when ctx.id is nil" do
               adapter = {{factory.body}}
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Remove, id: nil)
-              error = expect_raises(Alumna::ServiceError) { adapter.remove(ctx) }
-              error.status.should eq(400)
+              result = adapter.remove(ctx)
+              result.should be_a(Alumna::ServiceError)
+              result.as(Alumna::ServiceError).status.should eq(400)
             end
           end
 
@@ -470,7 +468,7 @@ module Alumna
               count.times { done.receive }
 
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find)
-              records = adapter.find(ctx)
+              records = adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData)))
 
               records.size.should eq(count)
               ids = records.map { |rec| rec["id"].as(String).to_i64 }.sort!
@@ -488,7 +486,7 @@ module Alumna
               writers.times do
                 spawn do
                   get_ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Get, id: id)
-                  if current = adapter.get(get_ctx)
+                  if current = adapter.get(get_ctx).as?(Hash(String, Alumna::AnyData))
                     val = current["counter"].as(Int64)
                     patch_ctx = Alumna::Testing.build_ctx(
                       service: adapter,
@@ -505,7 +503,7 @@ module Alumna
 
               writers.times { done.receive }
 
-              final = adapter.get(Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Get, id: id))
+              final = adapter.get(Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Get, id: id)).as?(Hash(String, Alumna::AnyData))
               final.should_not be_nil
               if final
                 final["counter"].as(Int64).should be >= 1
@@ -529,14 +527,14 @@ module Alumna
               spawn do
                 50.times do
                   ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find)
-                  adapter.find(ctx).size.should be >= 0
+                  adapter.find(ctx).as(Array(Hash(String, Alumna::AnyData))).size.should be >= 0
                   Fiber.yield
                 end
                 done.send(nil)
               end
 
               2.times { done.receive }
-              adapter.find(Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find)).size.should eq(50)
+              adapter.find(Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find)).as(Array(Hash(String, Alumna::AnyData))).size.should eq(50)
             end
           end
         end

--- a/src/testing/adapter_suite.cr
+++ b/src/testing/adapter_suite.cr
@@ -120,15 +120,58 @@ module Alumna
               results.first["role"].should eq("user")
             end
 
-            it "filters records using $gt and $lt operators" do
+            it "filters records using $gt and $lt operators on Int64" do
               adapter = {{factory.body}}
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(10)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(20)} of String => Alumna::AnyData)
               Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any(30)} of String => Alumna::AnyData)
+
               ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"age[$gt]" => "15", "age[$lt]" => "25"})
               results = adapter.find(ctx)
               results.size.should eq(1)
               results.first["age"].should eq(20)
+
+              # Test invalid integer parsing gracefully falling back
+              ctx2 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"age[$gt]" => "abc"})
+              adapter.find(ctx2).should be_empty
+            end
+
+            it "filters records using $gt and $lt operators on Float64" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"rating" => Alumna::Testing::AdapterSuiteHelpers.any(3.5)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"rating" => Alumna::Testing::AdapterSuiteHelpers.any(4.5)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"rating" => Alumna::Testing::AdapterSuiteHelpers.any(5.0)} of String => Alumna::AnyData)
+
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"rating[$gt]" => "4.0", "rating[$lt]" => "4.9"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["rating"].should eq(4.5)
+
+              # Test invalid float parsing gracefully falling back
+              ctx2 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"rating[$gt]" => "abc"})
+              adapter.find(ctx2).should be_empty
+            end
+
+            it "filters records using $gt and $lt operators on Bool" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"active" => Alumna::Testing::AdapterSuiteHelpers.any(true)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"active" => Alumna::Testing::AdapterSuiteHelpers.any(false)} of String => Alumna::AnyData)
+
+              # true (1) > false (0)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"active[$gt]" => "false"})
+              results = adapter.find(ctx)
+              results.size.should eq(1)
+              results.first["active"].should eq(true)
+
+              # false (0) < true (1)
+              ctx2 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"active[$lt]" => "true"})
+              results2 = adapter.find(ctx2)
+              results2.size.should eq(1)
+              results2.first["active"].should eq(false)
+
+              # Test invalid bool parsing gracefully falling back
+              ctx3 = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"active[$gt]" => "not-a-bool"})
+              adapter.find(ctx3).should be_empty
             end
 
             it "filters strings using $gt operator lexicographically" do

--- a/src/testing/adapter_suite.cr
+++ b/src/testing/adapter_suite.cr
@@ -16,6 +16,10 @@ module Alumna
         v.to_i64
       end
 
+      def self.any(v : Float) : AnyData
+        v.to_f64
+      end
+
       def self.insert(adapter : Service, data : Hash(String, AnyData))
         ctx = Alumna::Testing.build_ctx(
           service: adapter,
@@ -118,12 +122,32 @@ module Alumna
               results.map(&.["n"]).should eq(["1", "2"])
             end
 
-            it "applies $sort" do
+            it "applies $sort correctly with numeric types (not lexicographical)" do
               adapter = {{factory.body}}
-              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any("30")} of String => Alumna::AnyData)
-              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"age" => Alumna::Testing::AdapterSuiteHelpers.any("20")} of String => Alumna::AnyData)
-              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "age:1"})
-              adapter.find(ctx).first["age"].should eq("20")
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"score" => Alumna::Testing::AdapterSuiteHelpers.any(100)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"score" => Alumna::Testing::AdapterSuiteHelpers.any(9)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"score" => Alumna::Testing::AdapterSuiteHelpers.any(25)} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "score:1"})
+              results = adapter.find(ctx)
+              results.map(&.["score"]).should eq([9_i64, 25_i64, 100_i64])
+            end
+
+            it "applies $sort correctly with mixed numbers (Int64 and Float64)" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"val" => Alumna::Testing::AdapterSuiteHelpers.any(10)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"val" => Alumna::Testing::AdapterSuiteHelpers.any(9.5)} of String => Alumna::AnyData)
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "val:1"})
+              adapter.find(ctx).map(&.["val"]).should eq([9.5_f64, 10_i64])
+            end
+
+            it "handles missing values in $sort gracefully" do
+              adapter = {{factory.body}}
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("A"), "pos" => Alumna::Testing::AdapterSuiteHelpers.any(2)} of String => Alumna::AnyData)
+              Alumna::Testing::AdapterSuiteHelpers.insert(adapter, {"name" => Alumna::Testing::AdapterSuiteHelpers.any("B")} of String => Alumna::AnyData) # Missing pos
+              ctx = Alumna::Testing.build_ctx(service: adapter, method: Alumna::ServiceMethod::Find, params: {"$sort" => "pos:1"})
+              results = adapter.find(ctx)
+              # Missing fields are evaluated as nil, so B should come before A
+              results.map(&.["name"]).should eq(["B", "A"])
             end
 
             it "applies $select" do


### PR DESCRIPTION
- perf: error rules pre-compilation
- fix: type-aware comparison to MemoryAdapter#find
- test: also covers comparison of identical string or boolean types and the fallback for mismatched types
- feat: nested fields for schema and schema validator
- refactor: better handling of the result even when setting it as nil
- feat: automatic multi-thread workers when compiling with `-Dpreview_mt` `-Dexecution_context`
- chore: CI/CD tests now test both single and multi-thread modes
- feat: graceful shutdown
- test: fix graceful shutdown test for a race condition in multi-thread scenarios
- test: testing graceful shutdown with `SIGINT` and `SIGTERM`
- test: graceful shutdown when timeout is reached
- refactor: refactored and expanded `Alumna::Query`
- test: cover inequality operators (`$gt`, `$lt`, etc.) to Float64 and Bool fields
- refactor: dropping `raise ServiceError` in favor of returning a `ServiceError` struct, eliminating backtrace allocations from Crystal exceptions