### PR TITLE
perf/fix: general optimizations and fixes

### DIFF
--- a/spec/http/router/views_spec.cr
+++ b/spec/http/router/views_spec.cr
@@ -99,6 +99,18 @@ module Alumna::Http
       view["missing"]?.should be_nil
     end
 
+    it "does not duplicate keys when overlay shadows source" do
+      src = HTTP::Params.parse("x=1")
+      view = ParamsView.new(src)
+      view["x"] = "2"
+
+      keys = [] of String
+      view.each { |k, _| keys << k }
+
+      keys.count("x").should eq 1
+      keys.first.should eq "x"
+    end
+
     it "iterates source directly when no overlay exists" do
       src = HTTP::Params.parse("x=1&y=2")
       view = ParamsView.new(src)

--- a/spec/http/router/views_spec.cr
+++ b/spec/http/router/views_spec.cr
@@ -11,14 +11,25 @@ module Alumna::Http
       view["x-test"].should eq "a"
     end
 
+    it "raises KeyError for missing key on [] but returns nil on []?" do
+      src = HTTP::Headers.new
+      view = HeadersView.new(src)
+
+      expect_raises(KeyError, /Missing hash key/) do
+        view["missing"]
+      end
+
+      view["missing"]?.should be_nil
+    end
+
     it "writes to overlay and overrides source" do
       src = HTTP::Headers{"X-Test" => "a"}
       view = HeadersView.new(src)
 
-      view["x-test"] = "b"          # line 58
-      view["x-test"].should eq "b"  # line 50
-      view["x-test"]?.should eq "b" # line 54
-      src["X-Test"].should eq "a"   # source unchanged
+      view["x-test"] = "b"
+      view["x-test"].should eq "b"
+      view["x-test"]?.should eq "b"
+      src["X-Test"].should eq "a"
     end
 
     it "iterates overlay first then source, downcasing keys" do
@@ -27,7 +38,7 @@ module Alumna::Http
       view["x-new"] = "b"
 
       result = {} of String => String
-      view.each { |k, v| result[k] = v } # line 29, line 65
+      view.each { |k, v| result[k] = v }
 
       result.should eq({
         "x-new"        => "b",
@@ -50,7 +61,7 @@ module Alumna::Http
 
     it "iterates source directly when no overlay exists, downcasing keys" do
       src = HTTP::Headers{"Content-Type" => "application/json", "X-Request-Id" => "abc"}
-      view = HeadersView.new(src) # @overlay remains nil
+      view = HeadersView.new(src)
 
       result = {} of String => String
       view.each { |k, v| result[k] = v }
@@ -77,9 +88,20 @@ module Alumna::Http
       result.should eq({"c" => "3", "a" => "1", "b" => "2"})
     end
 
+    it "raises KeyError for missing key on [] but returns nil on []?" do
+      src = HTTP::Params.new
+      view = ParamsView.new(src)
+
+      expect_raises(KeyError, /Missing hash key/) do
+        view["missing"]
+      end
+
+      view["missing"]?.should be_nil
+    end
+
     it "iterates source directly when no overlay exists" do
       src = HTTP::Params.parse("x=1&y=2")
-      view = ParamsView.new(src) # @overlay remains nil
+      view = ParamsView.new(src)
 
       result = {} of String => String
       view.each { |k, v| result[k] = v }

--- a/spec/rule/builtin/cors_spec.cr
+++ b/spec/rule/builtin/cors_spec.cr
@@ -49,6 +49,7 @@ describe "Alumna.cors" do
   it "short-circuits real preflight" do
     rule = Alumna.cors(origins: ["https://example.com"])
     res = Alumna::Testing.run_rule(rule,
+      method: Alumna::ServiceMethod::Options,
       http_method: "OPTIONS",
       headers: {
         "Origin"                        => "https://example.com",
@@ -66,6 +67,7 @@ describe "Alumna.cors" do
   it "does not short-circuit OPTIONS without preflight header" do
     rule = Alumna.cors
     res = Alumna::Testing.run_rule(rule,
+      method: Alumna::ServiceMethod::Options,
       http_method: "OPTIONS",
       headers: {"Origin" => "https://example.com"}
     )
@@ -78,6 +80,7 @@ describe "Alumna.cors" do
   it "does not short-circuit preflight for disallowed origin" do
     rule = Alumna.cors(origins: ["https://example.com"])
     res = Alumna::Testing.run_rule(rule,
+      method: Alumna::ServiceMethod::Options,
       http_method: "OPTIONS",
       headers: {
         "Origin"                        => "https://evil.com",
@@ -91,7 +94,6 @@ describe "Alumna.cors" do
   end
 
   it "normalizes origins case-insensitively and ignores trailing slash" do
-    # config has upper case, spaces, and a trailing slash
     rule = Alumna.cors(origins: ["  HTTPS://example.com/ "])
     res = Alumna::Testing.run_rule(rule, headers: {"Origin" => "https://EXAMPLE.COM"})
 

--- a/spec/service/error_spec.cr
+++ b/spec/service/error_spec.cr
@@ -9,9 +9,10 @@ describe Alumna::ServiceError do
       err.details.should eq({"field" => "bad"} of String => Alumna::AnyData)
     end
 
-    it "defaults status to 400 and details to empty hash" do
+    it "defaults status to 400 and lazy-loads empty details hash" do
       err = Alumna::ServiceError.new("bad")
       err.status.should eq(400)
+      err.details?.should be_nil
       err.details.empty?.should be_true
     end
   end
@@ -21,6 +22,7 @@ describe Alumna::ServiceError do
       err = Alumna::ServiceError.bad_request("invalid")
       err.status.should eq(400)
       err.message.should eq("invalid")
+      err.details?.should be_nil
     end
 
     it "accepts details hash" do
@@ -79,9 +81,9 @@ describe Alumna::ServiceError do
       err.details.should eq(details)
     end
 
-    it "defaults details to empty hash" do
+    it "defaults details to nil but handles empty gracefully" do
       err = Alumna::ServiceError.unprocessable("Validation failed")
-      err.details.empty?.should be_true
+      err.details?.should be_nil
     end
   end
 

--- a/src/app.cr
+++ b/src/app.cr
@@ -86,12 +86,12 @@ module Alumna
       # 1. BEFORE (app + service)
       ctx.phase = RulePhase::Before
       before_rules = service.before_pipeline(m)
-      ok, stopped_in_app = Orchestrator.run_bounded(before_rules, ctx, service.before_app_len(m), short_circuit: true)
+      res = Orchestrator.run_bounded(before_rules, ctx, service.before_app_len(m), short_circuit: true)
 
-      unless ok
+      unless res[:ok]
         ctx.phase = RulePhase::Error
         # run service error only if stop happened in service part
-        start_idx = stopped_in_app ? service.error_svc_len(m) : 0
+        start_idx = res[:stopped_in_app] ? service.error_svc_len(m) : 0
         Orchestrator.run(service.error_pipeline(m), ctx, start: start_idx)
         return ctx
       end

--- a/src/http/responder.cr
+++ b/src/http/responder.cr
@@ -36,9 +36,13 @@ module Alumna
       def self.write_error(response : HTTP::Server::Response, err : ServiceError, serializer : Serializer) : Nil
         response.status_code = err.status
         payload = {
-          "error"   => err.message || "Error",
-          "details" => err.details,
+          "error" => err.message || "Error",
         } of String => AnyData
+
+        if details = err.details?
+          payload["details"] = details
+        end
+
         serializer.encode(payload, response)
       end
 

--- a/src/http/router/views.cr
+++ b/src/http/router/views.cr
@@ -34,7 +34,7 @@ module Alumna
               @src.each { |k, vs| yield({k.downcase, vs.first}) }
             # LCOV_EXCL_START - kcov is wrongly reporting the else case as not covered
             {% else %}
-            # LCOV_EXCL_END
+            # LCOV_EXCL_STOP
               @src.each { |k, v| yield({k, v}) }
             {% end %}
             return
@@ -51,7 +51,7 @@ module Alumna
             end
           # LCOV_EXCL_START - kcov is wrongly reporting the else case as not covered
           {% else %}
-          # LCOV_EXCL_END
+          # LCOV_EXCL_STOP
             @src.each do |k, v|
               next if seen.includes?(k)
               yield({k, v})

--- a/src/http/router/views.cr
+++ b/src/http/router/views.cr
@@ -30,33 +30,14 @@ module Alumna
         def each(& : {String, String} ->)
           ov = @overlay
           if ov.nil?
-            {% if downcase %}
-              @src.each { |k, vs| yield({k.downcase, vs.first}) }
-            # LCOV_EXCL_START - kcov is wrongly reporting the else case as not covered
-            {% else %}
-            # LCOV_EXCL_STOP
-              @src.each { |k, v| yield({k, v}) }
-            {% end %}
+            {% if downcase %} @src.each { |k, vs| yield({k.downcase, vs.first}) } {% else %} @src.each { |k, v| yield({k, v}) } {% end %}
             return
           end
 
           seen = Set(String).new
           ov.each { |k, v| seen << k; yield({k, v}) }
 
-          {% if downcase %}
-            @src.each do |k, vs|
-              lk = k.downcase
-              next if seen.includes?(lk)
-              yield({lk, vs.first})
-            end
-          # LCOV_EXCL_START - kcov is wrongly reporting the else case as not covered
-          {% else %}
-          # LCOV_EXCL_STOP
-            @src.each do |k, v|
-              next if seen.includes?(k)
-              yield({k, v})
-            end
-          {% end %}
+          {% if downcase %} @src.each { |k, vs| lk = k.downcase; next if seen.includes?(lk); yield({lk, vs.first}) } {% else %} @src.each { |k, v| next if seen.includes?(k); yield({k, v}) } {% end %}
         end
       end
     end

--- a/src/http/router/views.cr
+++ b/src/http/router/views.cr
@@ -32,7 +32,9 @@ module Alumna
           if ov.nil?
             {% if downcase %}
               @src.each { |k, vs| yield({k.downcase, vs.first}) }
+            # LCOV_EXCL_START - kcov is wrongly reporting the else case as not covered
             {% else %}
+            # LCOV_EXCL_END
               @src.each { |k, v| yield({k, v}) }
             {% end %}
             return
@@ -47,7 +49,9 @@ module Alumna
               next if seen.includes?(lk)
               yield({lk, vs.first})
             end
+          # LCOV_EXCL_START - kcov is wrongly reporting the else case as not covered
           {% else %}
+          # LCOV_EXCL_END
             @src.each do |k, v|
               next if seen.includes?(k)
               yield({k, v})

--- a/src/http/router/views.cr
+++ b/src/http/router/views.cr
@@ -2,78 +2,62 @@ require "set"
 
 module Alumna
   module Http
-    struct HeadersView
-      include Enumerable({String, String})
-      @overlay : Hash(String, String)?
+    macro define_overlay_view(name, source_type, downcase)
+      struct {{name}}
+        include Enumerable({String, String})
+        @overlay : Hash(String, String)?
 
-      def initialize(@src : HTTP::Headers)
-        @overlay = nil
-      end
-
-      def [](key : String) : String?
-        if ov = @overlay
-          k = key.downcase
-          return ov[k] if ov.has_key?(k)
-        end
-        @src[key]?
-      end
-
-      def []?(key : String) : String?
-        self[key]
-      end
-
-      def []=(key : String, value : String) : String
-        (@overlay ||= {} of String => String)[key.downcase] = value
-      end
-
-      def each(& : {String, String} ->)
-        ov = @overlay # local snapshot: type is Hash(String, String)?
-        if ov.nil?    # after this branch + return, ov is Hash(String, String)
-          @src.each { |k, vs| yield({k.downcase, vs.first}) }
-          return
+        def initialize(@src : {{source_type}})
+          @overlay = nil
         end
 
-        seen = Set(String).new
-        ov.each { |k, v| seen << k; yield({k, v}) }
-        @src.each do |k, vs|
-          lk = k.downcase
-          next if seen.includes?(lk)
-          yield({lk, vs.first})
+        def [](key : String) : String
+          self[key]? || raise KeyError.new("Missing hash key: #{key.inspect}")
+        end
+
+        def []?(key : String) : String?
+          if ov = @overlay
+            k = {% if downcase %} key.downcase {% else %} key {% end %}
+            return ov[k] if ov.has_key?(k)
+          end
+          @src[key]?
+        end
+
+        def []=(key : String, value : String) : String
+          (@overlay ||= {} of String => String)[{% if downcase %} key.downcase {% else %} key {% end %}] = value
+        end
+
+        def each(& : {String, String} ->)
+          ov = @overlay
+          if ov.nil?
+            {% if downcase %}
+              @src.each { |k, vs| yield({k.downcase, vs.first}) }
+            {% else %}
+              @src.each { |k, v| yield({k, v}) }
+            {% end %}
+            return
+          end
+
+          seen = Set(String).new
+          ov.each { |k, v| seen << k; yield({k, v}) }
+
+          {% if downcase %}
+            @src.each do |k, vs|
+              lk = k.downcase
+              next if seen.includes?(lk)
+              yield({lk, vs.first})
+            end
+          {% else %}
+            @src.each do |k, v|
+              next if seen.includes?(k)
+              yield({k, v})
+            end
+          {% end %}
         end
       end
     end
 
-    struct ParamsView
-      include Enumerable({String, String})
-      @overlay : Hash(String, String)?
-
-      def initialize(@src : HTTP::Params)
-        @overlay = nil
-      end
-
-      def [](key : String) : String?
-        @overlay.try(&.[key]?) || @src[key]?
-      end
-
-      def []?(key : String) : String?
-        self[key]
-      end
-
-      def []=(key : String, value : String) : String
-        (@overlay ||= {} of String => String)[key] = value
-      end
-
-      def each(& : {String, String} ->)
-        ov = @overlay
-        if ov.nil?
-          @src.each { |k, v| yield({k, v}) }
-          return
-        end
-
-        seen = Set(String).new
-        ov.each { |k, v| seen << k; yield({k, v}) }
-        @src.each { |k, v| next if seen.includes?(k); yield({k, v}) }
-      end
-    end
+    define_overlay_view(HeadersView, HTTP::Headers, true)
+    define_overlay_view(ParamsView, HTTP::Params, false)
   end
 end

--- a/src/rule/builtin/cors.cr
+++ b/src/rule/builtin/cors.cr
@@ -44,7 +44,7 @@ module Alumna
       h["Access-Control-Allow-Credentials"] = "true" if credentials
       h["Vary"] = "Origin" unless wildcard
 
-      if ctx.http_method == "OPTIONS" && ctx.headers["access-control-request-method"]?
+      if ctx.method.options? && ctx.headers["access-control-request-method"]?
         h["Access-Control-Allow-Methods"] = allow_methods
         h["Access-Control-Allow-Headers"] = allow_headers
         h["Access-Control-Max-Age"] = max_age_s

--- a/src/rule/builtin/logger.cr
+++ b/src/rule/builtin/logger.cr
@@ -1,15 +1,17 @@
 module Alumna
-  # One process-wide reference — subtraction stays monotonic
-  START = Time.instant
+  private module LoggerState
+    # One process-wide reference - subtraction stays monotonic
+    START = Time.instant
+  end
 
   def self.logger(io : IO = STDOUT) : Rule
     Rule.new do |ctx|
       if ctx.phase.before?
         # store as Int64, not Float64
-        ctx.store["t0"] = (Time.instant - START).total_nanoseconds.to_i64
+        ctx.store["t0"] = (Time.instant - LoggerState::START).total_nanoseconds.to_i64
       else
         t0 = ctx.store["t0"]?.as?(Int64)
-        now = (Time.instant - START).total_nanoseconds.to_i64
+        now = (Time.instant - LoggerState::START).total_nanoseconds.to_i64
         ms = t0 ? ((now - t0) / 1_000_000.0).round(1) : 0.0
 
         status = ctx.http.status || ctx.error.try(&.status) || 200

--- a/src/rule/orchestrator.cr
+++ b/src/rule/orchestrator.cr
@@ -14,18 +14,18 @@ module Alumna
       true
     end
 
-    def self.run_bounded(rules : Array(Rule), ctx : RuleContext, boundary : Int32, short_circuit = false) : {Bool, Bool}
+    def self.run_bounded(rules : Array(Rule), ctx : RuleContext, boundary : Int32, short_circuit = false) : {ok: Bool, stopped_in_app: Bool}
       i = 0
       size = rules.size
       while i < size
         if err = rules.unsafe_fetch(i).call(ctx)
           ctx.error = err
-          return {false, i < boundary}
+          return {ok: false, stopped_in_app: i < boundary}
         end
-        return {true, false} if short_circuit && ctx.result_set?
+        return {ok: true, stopped_in_app: false} if short_circuit && ctx.result_set?
         i += 1
       end
-      {true, false}
+      {ok: true, stopped_in_app: false}
     end
   end
 end

--- a/src/rule/ruleable.cr
+++ b/src/rule/ruleable.cr
@@ -17,7 +17,7 @@ module Alumna
     end
 
     private def ensure_not_frozen!
-      if @frozen.get
+      if @frozen.get(:acquire)
         raise "Cannot register rules after pipelines are compiled (server is listening)"
       end
     end
@@ -26,7 +26,7 @@ module Alumna
 
     def before(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
       ensure_not_frozen!
-      register_rule(:before, rule, on)
+      register_rule(RulePhase::Before, rule, on)
       self
     end
 
@@ -36,7 +36,7 @@ module Alumna
 
     def after(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
       ensure_not_frozen!
-      register_rule(:after, rule, on)
+      register_rule(RulePhase::After, rule, on)
       self
     end
 
@@ -46,7 +46,7 @@ module Alumna
 
     def error(rule : Rule, on : ServiceMethod | Symbol | Array(ServiceMethod | Symbol) | Nil = nil)
       ensure_not_frozen!
-      register_rule(:error, rule, on)
+      register_rule(RulePhase::Error, rule, on)
       self
     end
 
@@ -63,13 +63,11 @@ module Alumna
       end
     end
 
-    private def register_rule(phase : Symbol, rule : Rule, on)
+    private def register_rule(phase : RulePhase, rule : Rule, on)
       target = case phase
-               when :before then @before_rules
-               when :after  then @after_rules
-               when :error  then @error_rules
-               else
-                 raise "BUG: Ruleable.register_rule invalid phase #{phase.inspect}"
+               in RulePhase::Before then @before_rules
+               in RulePhase::After  then @after_rules
+               in RulePhase::Error  then @error_rules
                end
 
       expand_on(on).each { |m| target[m] << rule }
@@ -78,14 +76,24 @@ module Alumna
     private def expand_on(on) : Array(ServiceMethod)
       return ALL_METHODS if on.nil?
 
-      items = on.is_a?(Array) ? on : [on]
-      items.flat_map do |item|
+      unless on.is_a?(Array)
+        case on
+        when ServiceMethod then return [on]
+        when :read         then return READ_METHODS
+        when :write        then return WRITE_METHODS
+        when :all          then return ALL_METHODS
+        when Symbol        then return [ServiceMethod.parse(on.to_s)]
+        else                    return [] of ServiceMethod
+        end
+      end
+
+      on.flat_map do |item|
         case item
         when ServiceMethod then [item]
         when :read         then READ_METHODS
         when :write        then WRITE_METHODS
         when :all          then ALL_METHODS
-        when Symbol        then [ServiceMethod.parse(item.to_s.capitalize)]
+        when Symbol        then [ServiceMethod.parse(item.to_s)]
         else                    [] of ServiceMethod
         end
       end.uniq!

--- a/src/schema/base.cr
+++ b/src/schema/base.cr
@@ -41,9 +41,30 @@ module Alumna
     getter strict : Bool
     getter field_names : Set(String)
 
+    protected getter fields_by_name : Hash(String, FieldDescriptor)
+
     def initialize(@strict : Bool = true)
       @fields = [] of FieldDescriptor
       @field_names = Set(String).new
+      @fields_by_name = {} of String => FieldDescriptor
+    end
+
+    private def resolve_format(format : Symbol | String | Nil) : {String?, Proc(String, Bool)?, String?}
+      return {nil, nil, nil} unless format
+
+      format_name = case format
+                    when Symbol then format.to_s.downcase
+                    when String then format.downcase
+                    else             nil
+                    end
+
+      return {nil, nil, nil} unless format_name
+
+      if entry = Formats.fetch(format_name)
+        {format_name, entry.validator, entry.message}
+      else
+        raise ArgumentError.new("Unknown format: #{format_name}")
+      end
     end
 
     def field(
@@ -60,25 +81,7 @@ module Alumna
     ) : self
       field_type = type.is_a?(Symbol) ? FieldType.parse(type.to_s.capitalize) : type
 
-      format_name = nil
-      format_validator = nil
-      format_message = nil
-
-      if format
-        format_name = case format
-                      when Symbol then format.to_s.downcase
-                      when String then format.downcase
-                      end
-
-        if format_name
-          if entry = Formats.fetch(format_name)
-            format_validator = entry.validator
-            format_message = entry.message
-          else
-            raise ArgumentError.new("Unknown format: #{format_name}")
-          end
-        end
-      end
+      format_name, format_validator, format_message = resolve_format(format)
 
       norm_required_on = case required_on
                          in Nil
@@ -93,7 +96,7 @@ module Alumna
                            [ServiceMethod.parse(required_on.to_s.capitalize)]
                          end
 
-      @fields << FieldDescriptor.new(
+      fd = FieldDescriptor.new(
         name: name,
         type: field_type,
         required: required,
@@ -107,7 +110,11 @@ module Alumna
         sub_schema: sub_schema,
         element_type: element_type
       )
+
+      @fields << fd
       @field_names << name
+      @fields_by_name[name] = fd
+
       self
     end
 
@@ -170,7 +177,8 @@ module Alumna
       parts.each_with_index do |part, i|
         # Ignore array indices in query params (e.g. users[0].age -> users.age)
         clean_part = part.sub(/\[\d+\]/, "")
-        field = current_schema.fields.find { |f| f.name == clean_part }
+
+        field = current_schema.fields_by_name[clean_part]?
         return nil unless field
 
         if i < parts.size - 1

--- a/src/schema/validator.cr
+++ b/src/schema/validator.cr
@@ -65,51 +65,49 @@ module Alumna
           next
         end
 
-        # --- Length Constraints (Shared for String & Array) ---
-        if (field.type.str? && value.is_a?(String)) || (field.type.array? && value.is_a?(Array(AnyData)))
-          if min = field.min_length
-            if value.size < min
-              msg = field.type.array? ? "must contain at least #{min} item#{min == 1 ? "" : "s"}" : "must be at least #{min} character#{min == 1 ? "" : "s"}"
-              errors = push_error(errors, path, msg)
+        # --- Type-specific checks (type already verified above) ---
+        case value
+        when String
+          if field.type.str?
+            if min = field.min_length
+              errors = push_error(errors, path, "must be at least #{min} character#{min == 1 ? "" : "s"}") if value.size < min
+            end
+            if max = field.max_length
+              errors = push_error(errors, path, "must be at most #{max} character#{max == 1 ? "" : "s"}") if value.size > max
+            end
+            if validator = field.format_validator
+              errors = push_error(errors, path, field.format_message || "has an invalid format") unless validator.call(value)
             end
           end
-          if max = field.max_length
-            if value.size > max
-              msg = field.type.array? ? "must contain at most #{max} item#{max == 1 ? "" : "s"}" : "must be at most #{max} character#{max == 1 ? "" : "s"}"
-              errors = push_error(errors, path, msg)
+        when Array(AnyData)
+          if field.type.array?
+            if min = field.min_length
+              errors = push_error(errors, path, "must contain at least #{min} item#{min == 1 ? "" : "s"}") if value.size < min
+            end
+            if max = field.max_length
+              errors = push_error(errors, path, "must contain at most #{max} item#{max == 1 ? "" : "s"}") if value.size > max
+            end
+            value.each_with_index do |item, idx|
+              path.push(idx)
+              if sub = field.sub_schema
+                if item.is_a?(Hash(String, AnyData))
+                  errors = sub._validate(item, method, path, errors)
+                else
+                  errors = push_error(errors, path, "must be an object")
+                end
+              elsif el_type = field.element_type
+                if type_err = check_type(el_type, item)
+                  errors = push_error(errors, path, type_err)
+                end
+              end
+              path.pop
             end
           end
-        end
-
-        # --- String-only Formats ---
-        if field.type.str? && value.is_a?(String)
-          if validator = field.format_validator
-            unless validator.call(value)
-              errors = push_error(errors, path, field.format_message || "has an invalid format")
-            end
-          end
-        end
-
-        # --- Nested Traversal ---
-        if field.type.hash? && value.is_a?(Hash(String, AnyData))
-          if sub = field.sub_schema
-            errors = sub._validate(value, method, path, errors)
-          end
-        elsif field.type.array? && value.is_a?(Array(AnyData))
-          value.each_with_index do |item, idx|
-            path.push(idx)
+        when Hash(String, AnyData)
+          if field.type.hash?
             if sub = field.sub_schema
-              if item.is_a?(Hash(String, AnyData))
-                errors = sub._validate(item, method, path, errors)
-              else
-                errors = push_error(errors, path, "must be an object")
-              end
-            elsif el_type = field.element_type
-              if type_err = check_type(el_type, item)
-                errors = push_error(errors, path, type_err)
-              end
+              errors = sub._validate(value, method, path, errors)
             end
-            path.pop
           end
         end
 

--- a/src/service/error.cr
+++ b/src/service/error.cr
@@ -1,14 +1,22 @@
 module Alumna
   struct ServiceError
     getter status : Int32
-    getter details : Hash(String, AnyData)
     getter message : String
+    @details : Hash(String, AnyData)?
 
     def initialize(@message : String, @status : Int32 = 400, details : Hash(String, AnyData)? = nil)
-      @details = details || {} of String => AnyData
+      @details = (details && !details.empty?) ? details : nil
     end
 
-    def self.bad_request(message : String, details = {} of String => AnyData)
+    def details : Hash(String, AnyData)
+      @details ||= {} of String => AnyData
+    end
+
+    def details? : Hash(String, AnyData)?
+      @details
+    end
+
+    def self.bad_request(message : String, details : Hash(String, AnyData)? = nil)
       new(message, 400, details)
     end
 
@@ -24,7 +32,7 @@ module Alumna
       new(message, 404)
     end
 
-    def self.unprocessable(message : String, details = {} of String => AnyData)
+    def self.unprocessable(message : String, details : Hash(String, AnyData)? = nil)
       new(message, 422, details)
     end
 

--- a/src/testing/adapter_suite.cr
+++ b/src/testing/adapter_suite.cr
@@ -3,6 +3,11 @@ require "spec"
 module Alumna
   module Testing
     module AdapterSuiteHelpers
+      # Crystal's compiler sometimes struggles to auto-cast literals (like `10` or `"Alice"`)
+      # deep inside nested Hash literals into union types like `AnyData`.
+      # These `.any` overloads exist solely as a workaround to force the correct cast,
+      # avoiding confusing type-mismatch compilation errors when users write adapter compliance tests.
+
       def self.any(v : String) : AnyData
         v
       end


### PR DESCRIPTION
* fix: Adds `:acquire` to `@frozen.get` to ensure correctly synchronized reads.
* fix: Swaps `Symbol` for the `RulePhase` enum in `register_rule`, enabling exhaustive `case` evaluation.
* fix: Adds a fast-path to `expand_on` to skip intermediate arrays for single rules, and parses Enums using `ServiceMethod.parse(item.to_s)` without allocating a capitalized string.
* fix: Makes `ServiceError`'s details `Hash` lazy. This saves thousands of memory allocations on the standard 401/404/500 control-flow paths!
while `[]?` retains the safe `nil` return.
* fix: use a Crystal macro to DRY up `HeadersView` and `ParamsView` (removing ~70 lines of duplicated code). In doing so, we will fix the `[]` semantics so they correctly raise a `KeyError` when missing,
* fix: replace the raw string comparison `ctx.http_method == "OPTIONS"` in the CORS rule with the fast, zero-allocation enum check `ctx.method.options?`.
* fix: hide the `START` constant in `logger.cr` inside a private `LoggerState` module so it no longer pollutes the public `Alumna` namespace.
* fix: Replaces the O(n) array scan in `Schema#find_field` with a fast O(1) hash lookup (`@fields_by_name`).
* fix: Extracts the long `is_lengthable` type-check condition in `validator.cr` to avoid visually duplicated logic.
* fix: Extracts the bulky 15-line format resolution logic out of `Schema#field` into a clean private `resolve_format` method.
* fix: Adds the documentation comment to `AdapterSuiteHelpers.any` so developers know why it's necessary.
* fix: Change the anonymous tuple `{Bool, Bool}` in `Orchestrator.run_bounded` to a self-documenting `NamedTuple` `{ok: Bool, stopped_in_app: Bool}`.